### PR TITLE
Update environment variable names in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgis/postgis:16-3.4
@@ -52,11 +50,11 @@ services:
       SPRING_FLYWAY_VALIDATE_ON_MIGRATE: true
 
       # Server Configuration
-      SERVER_PORT: ${APP_PORT:-8080}
+      APP_PORT: ${APP_PORT:-8080}
 
       # Application Configuration
-      FITPUB_DOMAIN: ${APP_DOMAIN}
-      FITPUB_BASE_URL: ${APP_BASE_URL}
+      FITPUB_DOMAIN: ${FITPUB_DOMAIN}
+      FITPUB_BASE_URL: ${FITPUB_BASE_URL}
 
       # Security Configuration
       JWT_SECRET: ${JWT_SECRET}
@@ -64,6 +62,8 @@ services:
 
       # ActivityPub Configuration
       ACTIVITYPUB_ENABLED: ${ACTIVITYPUB_ENABLED:-true}
+
+      REGISTRATION_PASSWORD: ${REGISTRATION_PASSWORD}
 
       # File Storage
       FILE_UPLOAD_MAX_SIZE: ${FILE_UPLOAD_MAX_SIZE:-50MB}


### PR DESCRIPTION
The `APP_DOMAIN` and `APP_BASE_URL` variables are inconsistent with both the `.env.example` and with the naming of the rest of the variables. Additionally, allow the registration password be set.