### PR TITLE
fix(activity-detail): preserve line breaks in activity descriptions

### DIFF
--- a/src/main/resources/static/css/fitpub.css
+++ b/src/main/resources/static/css/fitpub.css
@@ -92,6 +92,11 @@ p,
     letter-spacing: normal;
 }
 
+/* Preserve line-breaks */
+.preserve-linebreaks {
+    white-space: pre-line;
+}
+
 /* Navigation */
 .navbar {
     background: linear-gradient(135deg, var(--dark-color) 0%, #2d0052 100%) !important;

--- a/src/main/resources/templates/activities/detail.html
+++ b/src/main/resources/templates/activities/detail.html
@@ -53,7 +53,7 @@
                                     <span id="activityVisibility"></span>
                                 </span>
                             </p>
-                            <p id="activityDescription" class="text-muted"></p>
+                            <p id="activityDescription" class="preserve-linebreaks text-muted"></p>
                         </div>
                         <div class="btn-group" role="group" id="activityActions" style="display: none;">
                             <a href="#" id="editBtn" class="btn btn-outline-primary">


### PR DESCRIPTION
- implement new CSS class `preserve-linebreaks` in `fitpub.css`
- add new CSS class to activity description element in `detail.html`