### PR TITLE
Fix concurrent activity summary insert conflicts

### DIFF
--- a/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
@@ -8,6 +8,7 @@ import net.javahippie.fitpub.repository.ActivityRepository;
 import net.javahippie.fitpub.repository.ActivitySummaryRepository;
 import net.javahippie.fitpub.repository.AchievementRepository;
 import net.javahippie.fitpub.repository.PersonalRecordRepository;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,17 +68,7 @@ public class ActivitySummaryService {
         LocalDate weekStart = date.with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
         LocalDate weekEnd = weekStart.plusDays(6);
 
-        ActivitySummary summary = activitySummaryRepository
-                .findByUserIdAndPeriodTypeAndPeriodStart(userId, ActivitySummary.PeriodType.WEEK, weekStart)
-                .orElse(ActivitySummary.builder()
-                        .userId(userId)
-                        .periodType(ActivitySummary.PeriodType.WEEK)
-                        .periodStart(weekStart)
-                        .periodEnd(weekEnd)
-                        .build());
-
-        calculateAndUpdateSummary(summary, userId, weekStart.atStartOfDay(), weekEnd.plusDays(1).atStartOfDay());
-        activitySummaryRepository.save(summary);
+        saveSummaryWithRetry(userId, ActivitySummary.PeriodType.WEEK, weekStart, weekEnd);
     }
 
     /**
@@ -88,17 +79,7 @@ public class ActivitySummaryService {
         LocalDate monthStart = date.with(TemporalAdjusters.firstDayOfMonth());
         LocalDate monthEnd = date.with(TemporalAdjusters.lastDayOfMonth());
 
-        ActivitySummary summary = activitySummaryRepository
-                .findByUserIdAndPeriodTypeAndPeriodStart(userId, ActivitySummary.PeriodType.MONTH, monthStart)
-                .orElse(ActivitySummary.builder()
-                        .userId(userId)
-                        .periodType(ActivitySummary.PeriodType.MONTH)
-                        .periodStart(monthStart)
-                        .periodEnd(monthEnd)
-                        .build());
-
-        calculateAndUpdateSummary(summary, userId, monthStart.atStartOfDay(), monthEnd.plusDays(1).atStartOfDay());
-        activitySummaryRepository.save(summary);
+        saveSummaryWithRetry(userId, ActivitySummary.PeriodType.MONTH, monthStart, monthEnd);
     }
 
     /**
@@ -109,24 +90,53 @@ public class ActivitySummaryService {
         LocalDate yearStart = date.with(TemporalAdjusters.firstDayOfYear());
         LocalDate yearEnd = date.with(TemporalAdjusters.lastDayOfYear());
 
+        saveSummaryWithRetry(userId, ActivitySummary.PeriodType.YEAR, yearStart, yearEnd);
+    }
+
+    private void saveSummaryWithRetry(
+            UUID userId,
+            ActivitySummary.PeriodType periodType,
+            LocalDate periodStart,
+            LocalDate periodEnd
+    ) {
         ActivitySummary summary = activitySummaryRepository
-                .findByUserIdAndPeriodTypeAndPeriodStart(userId, ActivitySummary.PeriodType.YEAR, yearStart)
+                .findByUserIdAndPeriodTypeAndPeriodStart(userId, periodType, periodStart)
                 .orElse(ActivitySummary.builder()
                         .userId(userId)
-                        .periodType(ActivitySummary.PeriodType.YEAR)
-                        .periodStart(yearStart)
-                        .periodEnd(yearEnd)
+                        .periodType(periodType)
+                        .periodStart(periodStart)
+                        .periodEnd(periodEnd)
                         .build());
 
-        calculateAndUpdateSummary(summary, userId, yearStart.atStartOfDay(), yearEnd.plusDays(1).atStartOfDay());
-        activitySummaryRepository.save(summary);
+        LocalDateTime startDateTime = periodStart.atStartOfDay();
+        LocalDateTime endDateTime = periodEnd.plusDays(1).atStartOfDay();
+
+        calculateAndUpdateSummary(summary, userId, startDateTime, endDateTime);
+
+        try {
+            activitySummaryRepository.save(summary);
+        } catch (DataIntegrityViolationException e) {
+            log.debug(
+                    "Summary already created concurrently for user {}, period {} starting {}. Retrying as update.",
+                    userId,
+                    periodType,
+                    periodStart
+            );
+
+            ActivitySummary existingSummary = activitySummaryRepository
+                    .findByUserIdAndPeriodTypeAndPeriodStart(userId, periodType, periodStart)
+                    .orElseThrow(() -> e);
+
+            calculateAndUpdateSummary(existingSummary, userId, startDateTime, endDateTime);
+            activitySummaryRepository.save(existingSummary);
+        }
     }
 
     /**
      * Calculate and update summary statistics.
      */
     private void calculateAndUpdateSummary(ActivitySummary summary, UUID userId,
-                                          LocalDateTime startDateTime, LocalDateTime endDateTime) {
+                                           LocalDateTime startDateTime, LocalDateTime endDateTime) {
         // Get activities in period
         List<Activity> activities = activityRepository
                 .findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(userId, startDateTime, endDateTime);

--- a/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
@@ -1,0 +1,96 @@
+package net.javahippie.fitpub.service;
+
+import net.javahippie.fitpub.model.entity.Activity;
+import net.javahippie.fitpub.model.entity.ActivitySummary;
+import net.javahippie.fitpub.repository.ActivityRepository;
+import net.javahippie.fitpub.repository.ActivitySummaryRepository;
+import net.javahippie.fitpub.repository.AchievementRepository;
+import net.javahippie.fitpub.repository.PersonalRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ActivitySummaryServiceTest {
+
+    private ActivitySummaryRepository activitySummaryRepository;
+    private ActivityRepository activityRepository;
+    private PersonalRecordRepository personalRecordRepository;
+    private AchievementRepository achievementRepository;
+    private ActivitySummaryService service;
+
+    @BeforeEach
+    void setUp() {
+        activitySummaryRepository = mock(ActivitySummaryRepository.class);
+        activityRepository = mock(ActivityRepository.class);
+        personalRecordRepository = mock(PersonalRecordRepository.class);
+        achievementRepository = mock(AchievementRepository.class);
+        service = new ActivitySummaryService(
+                activitySummaryRepository,
+                activityRepository,
+                personalRecordRepository,
+                achievementRepository
+        );
+    }
+
+    @Test
+    @DisplayName("Should retry summary save as update when concurrent insert hits unique constraint")
+    void shouldRetrySummarySaveAfterConcurrentInsert() {
+        UUID userId = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        LocalDate date = LocalDate.of(2025, 10, 8);
+        LocalDate weekStart = LocalDate.of(2025, 10, 6);
+        LocalDate weekEnd = LocalDate.of(2025, 10, 12);
+
+        ActivitySummary existingSummary = ActivitySummary.builder()
+                .id(UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+                .userId(userId)
+                .periodType(ActivitySummary.PeriodType.WEEK)
+                .periodStart(weekStart)
+                .periodEnd(weekEnd)
+                .build();
+
+        //noinspection unchecked
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId, ActivitySummary.PeriodType.WEEK, weekStart
+        )).thenReturn(Optional.empty(), Optional.of(existingSummary));
+
+        when(activityRepository.findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(
+                eq(userId),
+                eq(weekStart.atStartOfDay()),
+                eq(weekEnd.plusDays(1).atStartOfDay())
+        )).thenReturn(List.of(
+                Activity.builder()
+                        .userId(userId)
+                        .activityType(Activity.ActivityType.RIDE)
+                        .startedAt(LocalDateTime.of(2025, 10, 8, 9, 0))
+                        .totalDurationSeconds(3600L)
+                        .build()
+        ));
+
+        when(personalRecordRepository.countByUserIdAndDateRange(any(), any(), any())).thenReturn(0L);
+        when(achievementRepository.countByUserIdAndDateRange(any(), any(), any())).thenReturn(0L);
+
+        when(activitySummaryRepository.save(any(ActivitySummary.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"))
+                .thenReturn(existingSummary);
+
+        service.updateWeeklySummary(userId, date);
+
+        verify(activitySummaryRepository, times(2))
+                .findByUserIdAndPeriodTypeAndPeriodStart(userId, ActivitySummary.PeriodType.WEEK, weekStart);
+        verify(activitySummaryRepository, times(2)).save(any(ActivitySummary.class));
+    }
+}


### PR DESCRIPTION
## Problem

When multiple activities were processed in quick succession, asynchronous updates of `ActivitySummary` entries could run into a race condition.

The sequence was:

1. Two activities for the same user were processed almost at the same time.
2. Both async tasks tried to update the same weekly/monthly/yearly summary.
3. Both tasks initially found no existing `ActivitySummary` row.
4. Both created a new entity for the same combination of:
   - `user_id`
   - `period_type`
   - `period_start`
5. The first insert succeeded, and the second one failed on the unique constraint.

This resulted in errors such as:

- `duplicate key value violates unique constraint "activity_summaries_user_id_period_type_period_start_key"`
- `DataIntegrityViolationException` in `updateSummariesForActivity(...)`

## Root cause

The summary update logic was not robust against concurrent inserts for the same period summary.

The code followed a pattern like:

- `findByUserIdAndPeriodTypeAndPeriodStart(...)`
- if not found: build a new `ActivitySummary`
- `save(...)`

This "check then insert" flow is not atomic under parallel execution.

## Impact

- The activity itself was still imported or saved successfully.
- The asynchronous summary update could fail afterward.
- This caused noisy log output and could leave weekly/monthly/yearly summaries temporarily inconsistent or delayed.

## Solution

The update flow now handles concurrent insert conflicts explicitly.

When saving a newly created summary fails with a `DataIntegrityViolationException`, the service assumes that another concurrent task has already created the row. It then reloads the existing `ActivitySummary`, recalculates the summary values for the same period, and saves the entity again as a normal update.

This keeps the asynchronous workflow intact while making summary updates resilient to concurrent activity processing.

## Expected behavior

If another concurrent task creates the same summary row first, the second task should not fail with an uncaught exception. It should reload the existing summary and continue with a normal update.