### PR TITLE
Fix achievement dates and rebuild analytics consistency #24

### DIFF
--- a/src/main/java/net/javahippie/fitpub/controller/AnalyticsController.java
+++ b/src/main/java/net/javahippie/fitpub/controller/AnalyticsController.java
@@ -134,6 +134,25 @@ public class AnalyticsController {
     }
 
     /**
+     * Rebuild achievements for the authenticated user.
+     */
+    @PostMapping("/achievements/rebuild")
+    public ResponseEntity<RebuildResponse> rebuildAchievements(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID userId = getUserId(userDetails);
+
+        try {
+            achievementService.rebuildAchievementsForUser(userId);
+            return ResponseEntity.ok(new RebuildResponse("Achievements recalculated successfully"));
+        } catch (Exception e) {
+            log.error("Failed to rebuild achievements for user {}", userDetails.getUsername(), e);
+            return ResponseEntity.internalServerError()
+                    .body(new RebuildResponse("Failed to recalculate achievements: " + e.getMessage()));
+        }
+    }
+
+    /**
      * Get training load for a date range.
      */
     @GetMapping("/training-load")
@@ -276,4 +295,6 @@ public class AnalyticsController {
             case UNKNOWN -> "Not enough data to calculate form status.";
         };
     }
+
+    private record RebuildResponse(String message) {}
 }

--- a/src/main/java/net/javahippie/fitpub/controller/AnalyticsController.java
+++ b/src/main/java/net/javahippie/fitpub/controller/AnalyticsController.java
@@ -285,6 +285,23 @@ public class AnalyticsController {
     }
 
     /**
+     * Get current year summary.
+     */
+    @GetMapping("/summaries/current-year")
+    public ResponseEntity<ActivitySummary> getCurrentYearSummary(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        UUID userId = getUserId(userDetails);
+        ActivitySummary summary = activitySummaryService.getCurrentYearSummary(userId);
+
+        if (summary == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(summary);
+    }
+
+    /**
      * Get form status description.
      */
     private String getFormStatusDescription(TrainingLoad.FormStatus status) {

--- a/src/main/java/net/javahippie/fitpub/repository/AchievementRepository.java
+++ b/src/main/java/net/javahippie/fitpub/repository/AchievementRepository.java
@@ -2,6 +2,7 @@ package net.javahippie.fitpub.repository;
 
 import net.javahippie.fitpub.model.entity.Achievement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -39,6 +40,12 @@ public interface AchievementRepository extends JpaRepository<Achievement, UUID> 
      * Get count of achievements earned by a user.
      */
     long countByUserId(UUID userId);
+
+    /**
+     * Delete all achievements for a user.
+     */
+    @Modifying
+    void deleteByUserId(UUID userId);
 
     /**
      * Get count of achievements earned by a user in a date range.

--- a/src/main/java/net/javahippie/fitpub/repository/AchievementRepository.java
+++ b/src/main/java/net/javahippie/fitpub/repository/AchievementRepository.java
@@ -61,6 +61,23 @@ public interface AchievementRepository extends JpaRepository<Achievement, UUID> 
     );
 
     /**
+     * Count achievements whose triggering activity started within a date range.
+     */
+    @Query(value = """
+            SELECT COUNT(*)
+            FROM achievements ach
+            JOIN activities act ON act.id = ach.activity_id
+            WHERE ach.user_id = :userId
+              AND act.started_at >= :startDate
+              AND act.started_at < :endDate
+            """, nativeQuery = true)
+    long countByUserIdAndActivityStartedDateRange(
+            @Param("userId") UUID userId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
+
+    /**
      * Find recent achievements for a user.
      */
     @Query("SELECT a FROM Achievement a " +

--- a/src/main/java/net/javahippie/fitpub/repository/ActivityRepository.java
+++ b/src/main/java/net/javahippie/fitpub/repository/ActivityRepository.java
@@ -48,9 +48,15 @@ public interface ActivityRepository extends JpaRepository<Activity, UUID> {
      * @return list of activities
      */
     List<Activity> findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(
-        UUID userId,
-        LocalDateTime startDate,
-        LocalDateTime endDate
+            UUID userId,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
+
+    boolean existsByUserIdAndStartedAtBetween(
+            UUID userId,
+            LocalDateTime startDate,
+            LocalDateTime endDate
     );
 
     /**

--- a/src/main/java/net/javahippie/fitpub/repository/ActivityRepository.java
+++ b/src/main/java/net/javahippie/fitpub/repository/ActivityRepository.java
@@ -32,6 +32,14 @@ public interface ActivityRepository extends JpaRepository<Activity, UUID> {
     List<Activity> findByUserIdOrderByStartedAtDesc(UUID userId);
 
     /**
+     * Find all activities for a specific user in chronological order.
+     *
+     * @param userId the user ID
+     * @return list of activities
+     */
+    List<Activity> findByUserIdOrderByStartedAtAsc(UUID userId);
+
+    /**
      * Find all activities for a user within a date range.
      *
      * @param userId the user ID

--- a/src/main/java/net/javahippie/fitpub/repository/PersonalRecordRepository.java
+++ b/src/main/java/net/javahippie/fitpub/repository/PersonalRecordRepository.java
@@ -36,6 +36,11 @@ public interface PersonalRecordRepository extends JpaRepository<PersonalRecord, 
     );
 
     /**
+     * Delete all personal records for a user.
+     */
+    void deleteByUserId(UUID userId);
+
+    /**
      * Get count of personal records set by a user.
      */
     @Query("SELECT COUNT(pr) FROM PersonalRecord pr WHERE pr.userId = :userId")

--- a/src/main/java/net/javahippie/fitpub/service/AchievementService.java
+++ b/src/main/java/net/javahippie/fitpub/service/AchievementService.java
@@ -41,10 +41,8 @@ public class AchievementService {
      */
     @Transactional
     public List<Achievement> checkAndAwardAchievements(Activity activity) {
-        List<Achievement> newAchievements = new ArrayList<>();
-
         if (activity.getUserId() == null || activity.getStartedAt() == null || activity.getEndedAt() == null) {
-            return newAchievements;
+            return List.of();
         }
 
         UUID userId = activity.getUserId();
@@ -58,6 +56,15 @@ public class AchievementService {
         for (Achievement a : achievementRepository.findByUserIdOrderByEarnedAtDesc(userId)) {
             existing.add(a.getAchievementType());
         }
+
+        return checkAndAwardAchievements(activity, progress, existing);
+    }
+
+    private List<Achievement> checkAndAwardAchievements(Activity activity,
+                                                        ActivityProgress progress,
+                                                        Set<Achievement.AchievementType> existing) {
+        List<Achievement> newAchievements = new ArrayList<>();
+        UUID userId = activity.getUserId();
 
         // Check first activity achievements
         newAchievements.addAll(checkFirstActivityAchievements(userId, activity, progress, existing));
@@ -83,6 +90,10 @@ public class AchievementService {
         // Check speed achievements
         newAchievements.addAll(checkSpeedAchievements(userId, activity, progress, existing));
 
+        for (Achievement achievement : newAchievements) {
+            existing.add(achievement.getAchievementType());
+        }
+
         return newAchievements;
     }
 
@@ -103,9 +114,15 @@ public class AchievementService {
 
         achievementRepository.deleteByUserId(userId);
 
+        Set<Achievement.AchievementType> existing = EnumSet.noneOf(Achievement.AchievementType.class);
         List<Achievement> rebuiltAchievements = new ArrayList<>();
-        for (Activity activity : activityHistory) {
-            rebuiltAchievements.addAll(checkAndAwardAchievements(activity));
+        for (int i = 0; i < activityHistory.size(); i++) {
+            Activity activity = activityHistory.get(i);
+            rebuiltAchievements.addAll(checkAndAwardAchievements(
+                    activity,
+                    ActivityProgress.fromHistory(activityHistory, i),
+                    existing
+            ));
         }
 
         return rebuiltAchievements;
@@ -560,6 +577,10 @@ public class AchievementService {
                 throw new IllegalStateException("Current activity missing from chronological history: " + currentActivity.getId());
             }
 
+            return fromHistory(activityHistory, currentIndex);
+        }
+
+        private static ActivityProgress fromHistory(List<Activity> activityHistory, int currentIndex) {
             return new ActivityProgress(
                     List.copyOf(activityHistory.subList(0, currentIndex)),
                     List.copyOf(activityHistory.subList(0, currentIndex + 1))

--- a/src/main/java/net/javahippie/fitpub/service/AchievementService.java
+++ b/src/main/java/net/javahippie/fitpub/service/AchievementService.java
@@ -43,11 +43,13 @@ public class AchievementService {
     public List<Achievement> checkAndAwardAchievements(Activity activity) {
         List<Achievement> newAchievements = new ArrayList<>();
 
-        if (activity.getUserId() == null) {
+        if (activity.getUserId() == null || activity.getStartedAt() == null || activity.getEndedAt() == null) {
             return newAchievements;
         }
 
         UUID userId = activity.getUserId();
+        List<Activity> activityHistory = activityRepository.findByUserIdOrderByStartedAtAsc(userId);
+        ActivityProgress progress = ActivityProgress.fromHistory(activityHistory, activity);
 
         // Load all of the user's existing achievement types in a single query so the
         // sub-checks below can do an in-memory `contains()` instead of an EXISTS query
@@ -58,28 +60,28 @@ public class AchievementService {
         }
 
         // Check first activity achievements
-        newAchievements.addAll(checkFirstActivityAchievements(userId, activity, existing));
+        newAchievements.addAll(checkFirstActivityAchievements(userId, activity, progress, existing));
 
         // Check distance milestones
-        newAchievements.addAll(checkDistanceMilestones(userId, existing));
+        newAchievements.addAll(checkDistanceMilestones(userId, activity, progress, existing));
 
         // Check activity count milestones
-        newAchievements.addAll(checkActivityCountMilestones(userId, existing));
+        newAchievements.addAll(checkActivityCountMilestones(userId, activity, progress, existing));
 
         // Check streak achievements
-        newAchievements.addAll(checkStreakAchievements(userId, existing));
+        newAchievements.addAll(checkStreakAchievements(userId, activity, progress, existing));
 
         // Check time-based achievements
-        newAchievements.addAll(checkTimeBasedAchievements(userId, activity, existing));
+        newAchievements.addAll(checkTimeBasedAchievements(userId, activity, progress, existing));
 
         // Check elevation achievements
-        newAchievements.addAll(checkElevationAchievements(userId, activity, existing));
+        newAchievements.addAll(checkElevationAchievements(userId, activity, progress, existing));
 
         // Check variety achievements
-        newAchievements.addAll(checkVarietyAchievements(userId, existing));
+        newAchievements.addAll(checkVarietyAchievements(userId, activity, progress, existing));
 
         // Check speed achievements
-        newAchievements.addAll(checkSpeedAchievements(userId, activity, existing));
+        newAchievements.addAll(checkSpeedAchievements(userId, activity, progress, existing));
 
         return newAchievements;
     }
@@ -88,12 +90,14 @@ public class AchievementService {
      * Check first activity achievements.
      */
     private List<Achievement> checkFirstActivityAchievements(UUID userId, Activity activity,
+                                                             ActivityProgress progress,
                                                              Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
         // First activity overall
-        long totalActivities = activityRepository.countByUserId(userId);
-        if (totalActivities == 1 && !existing.contains(Achievement.AchievementType.FIRST_ACTIVITY)) {
+        if (progress.previousActivityCount() == 0 &&
+            progress.currentActivityCount() == 1 &&
+            !existing.contains(Achievement.AchievementType.FIRST_ACTIVITY)) {
             achievements.add(awardAchievement(
                     userId,
                     Achievement.AchievementType.FIRST_ACTIVITY,
@@ -102,15 +106,17 @@ public class AchievementService {
                     "🎉",
                     "#ff00ff",
                     activity.getId(),
+                    activity.getEndedAt(),
                     null
             ));
         }
 
         // First activity by type
         String activityType = activity.getActivityType().name();
-        long typeCount = activityRepository.countByUserIdAndActivityType(userId, activity.getActivityType());
+        long previousTypeCount = progress.previousActivityTypeCount(activity.getActivityType());
+        long currentTypeCount = progress.currentActivityTypeCount(activity.getActivityType());
 
-        if (typeCount == 1) {
+        if (previousTypeCount == 0 && currentTypeCount == 1) {
             Achievement.AchievementType achievementType = switch (activityType) {
                 case "RUN" -> Achievement.AchievementType.FIRST_RUN;
                 case "RIDE" -> Achievement.AchievementType.FIRST_RIDE;
@@ -127,6 +133,7 @@ public class AchievementService {
                         getActivityEmoji(activityType),
                         "#00ffff",
                         activity.getId(),
+                        activity.getEndedAt(),
                         null
                 ));
             }
@@ -138,16 +145,13 @@ public class AchievementService {
     /**
      * Check distance milestone achievements.
      */
-    private List<Achievement> checkDistanceMilestones(UUID userId, Set<Achievement.AchievementType> existing) {
+    private List<Achievement> checkDistanceMilestones(UUID userId, Activity activity,
+                                                      ActivityProgress progress,
+                                                      Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
-        // Calculate total distance
-        BigDecimal totalDistance = activityRepository.sumDistanceByUserId(userId);
-        if (totalDistance == null) {
-            return achievements;
-        }
-
-        double totalKm = totalDistance.doubleValue() / 1000.0;
+        double previousKm = progress.previousDistanceMeters().doubleValue() / 1000.0;
+        double currentKm = progress.currentDistanceMeters().doubleValue() / 1000.0;
 
         // Check milestones
         Map<Double, Achievement.AchievementType> milestones = Map.of(
@@ -159,7 +163,9 @@ public class AchievementService {
         );
 
         for (Map.Entry<Double, Achievement.AchievementType> entry : milestones.entrySet()) {
-            if (totalKm >= entry.getKey() && !existing.contains(entry.getValue())) {
+            if (previousKm < entry.getKey() &&
+                currentKm >= entry.getKey() &&
+                !existing.contains(entry.getValue())) {
                 achievements.add(awardAchievement(
                         userId,
                         entry.getValue(),
@@ -167,7 +173,8 @@ public class AchievementService {
                         String.format("Reached %.0f kilometers total distance!", entry.getKey()),
                         "🏃",
                         "#ffff00",
-                        null,
+                        activity.getId(),
+                        activity.getEndedAt(),
                         Map.of("distance_km", entry.getKey())
                 ));
             }
@@ -179,10 +186,10 @@ public class AchievementService {
     /**
      * Check activity count milestone achievements.
      */
-    private List<Achievement> checkActivityCountMilestones(UUID userId, Set<Achievement.AchievementType> existing) {
+    private List<Achievement> checkActivityCountMilestones(UUID userId, Activity activity,
+                                                           ActivityProgress progress,
+                                                           Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
-
-        long activityCount = activityRepository.countByUserId(userId);
 
         Map<Long, Achievement.AchievementType> milestones = Map.of(
                 10L, Achievement.AchievementType.ACTIVITIES_10,
@@ -193,7 +200,9 @@ public class AchievementService {
         );
 
         for (Map.Entry<Long, Achievement.AchievementType> entry : milestones.entrySet()) {
-            if (activityCount >= entry.getKey() && !existing.contains(entry.getValue())) {
+            if (progress.previousActivityCount() < entry.getKey() &&
+                progress.currentActivityCount() >= entry.getKey() &&
+                !existing.contains(entry.getValue())) {
                 achievements.add(awardAchievement(
                         userId,
                         entry.getValue(),
@@ -201,7 +210,8 @@ public class AchievementService {
                         String.format("Completed %d activities!", entry.getKey()),
                         "💪",
                         "#ff6600",
-                        null,
+                        activity.getId(),
+                        activity.getEndedAt(),
                         Map.of("activity_count", entry.getKey())
                 ));
             }
@@ -213,10 +223,13 @@ public class AchievementService {
     /**
      * Check streak achievements (consecutive days).
      */
-    private List<Achievement> checkStreakAchievements(UUID userId, Set<Achievement.AchievementType> existing) {
+    private List<Achievement> checkStreakAchievements(UUID userId, Activity activity,
+                                                      ActivityProgress progress,
+                                                      Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
-        int currentStreak = calculateCurrentStreak(userId);
+        int previousStreak = calculateStreak(progress.previousActivityDates(), activity.getEndedAt().toLocalDate());
+        int currentStreak = calculateStreak(progress.currentActivityDates(), activity.getEndedAt().toLocalDate());
 
         Map<Integer, Achievement.AchievementType> streakMilestones = Map.of(
                 7, Achievement.AchievementType.STREAK_7_DAYS,
@@ -226,7 +239,9 @@ public class AchievementService {
         );
 
         for (Map.Entry<Integer, Achievement.AchievementType> entry : streakMilestones.entrySet()) {
-            if (currentStreak >= entry.getKey() && !existing.contains(entry.getValue())) {
+            if (previousStreak < entry.getKey() &&
+                currentStreak >= entry.getKey() &&
+                !existing.contains(entry.getValue())) {
                 achievements.add(awardAchievement(
                         userId,
                         entry.getValue(),
@@ -234,7 +249,8 @@ public class AchievementService {
                         String.format("Worked out %d days in a row!", entry.getKey()),
                         "🔥",
                         "#ff1493",
-                        null,
+                        activity.getId(),
+                        activity.getEndedAt(),
                         Map.of("streak_days", entry.getKey())
                 ));
             }
@@ -247,6 +263,7 @@ public class AchievementService {
      * Check time-based achievements (early bird, night owl, weekend warrior).
      */
     private List<Achievement> checkTimeBasedAchievements(UUID userId, Activity activity,
+                                                         ActivityProgress progress,
                                                          Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
@@ -254,8 +271,9 @@ public class AchievementService {
 
         // Early bird (before 6am)
         if (startTime.isBefore(LocalTime.of(6, 0)) && !existing.contains(Achievement.AchievementType.EARLY_BIRD)) {
-            long earlyActivities = activityRepository.countByUserIdAndStartTimeBefore(userId, LocalTime.of(6, 0));
-            if (earlyActivities >= 5) {
+            long previousEarlyActivities = progress.previousActivitiesStartingBefore(LocalTime.of(6, 0));
+            long currentEarlyActivities = progress.currentActivitiesStartingBefore(LocalTime.of(6, 0));
+            if (previousEarlyActivities < 5 && currentEarlyActivities >= 5) {
                 achievements.add(awardAchievement(
                         userId,
                         Achievement.AchievementType.EARLY_BIRD,
@@ -264,15 +282,17 @@ public class AchievementService {
                         "🌅",
                         "#ccff00",
                         activity.getId(),
-                        Map.of("early_activities", earlyActivities)
+                        activity.getEndedAt(),
+                        Map.of("early_activities", currentEarlyActivities)
                 ));
             }
         }
 
         // Night owl (after 10pm)
         if (startTime.isAfter(LocalTime.of(22, 0)) && !existing.contains(Achievement.AchievementType.NIGHT_OWL)) {
-            long lateActivities = activityRepository.countByUserIdAndStartTimeAfter(userId, LocalTime.of(22, 0));
-            if (lateActivities >= 5) {
+            long previousLateActivities = progress.previousActivitiesStartingAfter(LocalTime.of(22, 0));
+            long currentLateActivities = progress.currentActivitiesStartingAfter(LocalTime.of(22, 0));
+            if (previousLateActivities < 5 && currentLateActivities >= 5) {
                 achievements.add(awardAchievement(
                         userId,
                         Achievement.AchievementType.NIGHT_OWL,
@@ -281,7 +301,8 @@ public class AchievementService {
                         "🦉",
                         "#9370db",
                         activity.getId(),
-                        Map.of("late_activities", lateActivities)
+                        activity.getEndedAt(),
+                        Map.of("late_activities", currentLateActivities)
                 ));
             }
         }
@@ -293,12 +314,14 @@ public class AchievementService {
      * Check elevation achievements.
      */
     private List<Achievement> checkElevationAchievements(UUID userId, Activity activity,
+                                                         ActivityProgress progress,
                                                          Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
         // Single activity elevation
         if (activity.getElevationGain() != null &&
             activity.getElevationGain().compareTo(BigDecimal.valueOf(1000)) >= 0 &&
+            !progress.previousHasElevationGainAtLeast(BigDecimal.valueOf(1000)) &&
             !existing.contains(Achievement.AchievementType.MOUNTAINEER_1000M)) {
 
             achievements.add(awardAchievement(
@@ -309,40 +332,45 @@ public class AchievementService {
                     "⛰️",
                     "#8b4513",
                     activity.getId(),
+                    activity.getEndedAt(),
                     Map.of("elevation_gain", activity.getElevationGain())
             ));
         }
 
         // Total elevation milestones
-        BigDecimal totalElevation = activityRepository.sumElevationGainByUserId(userId);
-        if (totalElevation != null) {
-            double totalM = totalElevation.doubleValue();
+        double previousElevation = progress.previousElevationMeters().doubleValue();
+        double currentElevation = progress.currentElevationMeters().doubleValue();
 
-            if (totalM >= 5000 && !existing.contains(Achievement.AchievementType.MOUNTAINEER_5000M)) {
-                achievements.add(awardAchievement(
-                        userId,
-                        Achievement.AchievementType.MOUNTAINEER_5000M,
-                        "Mountain Conqueror",
-                        "Climbed 5000m total elevation!",
-                        "🏔️",
-                        "#4169e1",
-                        null,
-                        Map.of("total_elevation", totalM)
-                ));
-            }
+        if (previousElevation < 5000 &&
+            currentElevation >= 5000 &&
+            !existing.contains(Achievement.AchievementType.MOUNTAINEER_5000M)) {
+            achievements.add(awardAchievement(
+                    userId,
+                    Achievement.AchievementType.MOUNTAINEER_5000M,
+                    "Mountain Conqueror",
+                    "Climbed 5000m total elevation!",
+                    "🏔️",
+                    "#4169e1",
+                    activity.getId(),
+                    activity.getEndedAt(),
+                    Map.of("total_elevation", currentElevation)
+            ));
+        }
 
-            if (totalM >= 10000 && !existing.contains(Achievement.AchievementType.MOUNTAINEER_10000M)) {
-                achievements.add(awardAchievement(
-                        userId,
-                        Achievement.AchievementType.MOUNTAINEER_10000M,
-                        "Summit Master",
-                        "Climbed 10000m total elevation!",
-                        "🗻",
-                        "#1e90ff",
-                        null,
-                        Map.of("total_elevation", totalM)
-                ));
-            }
+        if (previousElevation < 10000 &&
+            currentElevation >= 10000 &&
+            !existing.contains(Achievement.AchievementType.MOUNTAINEER_10000M)) {
+            achievements.add(awardAchievement(
+                    userId,
+                    Achievement.AchievementType.MOUNTAINEER_10000M,
+                    "Summit Master",
+                    "Climbed 10000m total elevation!",
+                    "🗻",
+                    "#1e90ff",
+                    activity.getId(),
+                    activity.getEndedAt(),
+                    Map.of("total_elevation", currentElevation)
+            ));
         }
 
         return achievements;
@@ -351,12 +379,17 @@ public class AchievementService {
     /**
      * Check variety achievements.
      */
-    private List<Achievement> checkVarietyAchievements(UUID userId, Set<Achievement.AchievementType> existing) {
+    private List<Achievement> checkVarietyAchievements(UUID userId, Activity activity,
+                                                       ActivityProgress progress,
+                                                       Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
-        long distinctActivityTypes = activityRepository.countDistinctActivityTypesByUserId(userId);
+        long previousDistinctActivityTypes = progress.previousDistinctActivityTypes();
+        long currentDistinctActivityTypes = progress.currentDistinctActivityTypes();
 
-        if (distinctActivityTypes >= 3 && !existing.contains(Achievement.AchievementType.VARIETY_SEEKER)) {
+        if (previousDistinctActivityTypes < 3 &&
+            currentDistinctActivityTypes >= 3 &&
+            !existing.contains(Achievement.AchievementType.VARIETY_SEEKER)) {
             achievements.add(awardAchievement(
                     userId,
                     Achievement.AchievementType.VARIETY_SEEKER,
@@ -364,8 +397,9 @@ public class AchievementService {
                     "Tried 3+ different activity types!",
                     "🌈",
                     "#ff69b4",
-                    null,
-                    Map.of("activity_types", distinctActivityTypes)
+                    activity.getId(),
+                    activity.getEndedAt(),
+                    Map.of("activity_types", currentDistinctActivityTypes)
             ));
         }
 
@@ -376,6 +410,7 @@ public class AchievementService {
      * Check speed achievements.
      */
     private List<Achievement> checkSpeedAchievements(UUID userId, Activity activity,
+                                                     ActivityProgress progress,
                                                      Set<Achievement.AchievementType> existing) {
         List<Achievement> achievements = new ArrayList<>();
 
@@ -383,7 +418,9 @@ public class AchievementService {
             // maxSpeed is already in km/h from FitParser
             double maxSpeedKmh = activity.getMetrics().getMaxSpeed().doubleValue();
 
-            if (maxSpeedKmh >= 40 && !existing.contains(Achievement.AchievementType.SPEED_DEMON)) {
+            if (maxSpeedKmh >= 40 &&
+                !progress.previousHasMaxSpeedAtLeast(BigDecimal.valueOf(40)) &&
+                !existing.contains(Achievement.AchievementType.SPEED_DEMON)) {
                 achievements.add(awardAchievement(
                         userId,
                         Achievement.AchievementType.SPEED_DEMON,
@@ -392,6 +429,7 @@ public class AchievementService {
                         "⚡",
                         "#ffd700",
                         activity.getId(),
+                        activity.getEndedAt(),
                         Map.of("max_speed_kmh", maxSpeedKmh)
                 ));
             }
@@ -401,69 +439,12 @@ public class AchievementService {
     }
 
     /**
-     * Calculate current activity streak (consecutive days).
-     *
-     * <p>Loads all activity timestamps for the user in the last 366 days in a single
-     * query, deduplicates them to a {@code Set<LocalDate>} in Java, and walks the
-     * resulting set in memory. Previously this method issued one {@code SELECT EXISTS}
-     * query per day (up to 365 round-trips per activity upload), which was the single
-     * biggest performance hot spot in the achievement evaluation path.
-     *
-     * <p>Java-side date deduplication is intentional: Hibernate 6 + Spring Data 3 do
-     * not reliably convert SQL date scalar projections to {@code List<LocalDate>}.
-     * The result set is small (a few hundred timestamps at most) so the cost of
-     * Java-side distinct is negligible.
-     *
-     * <p>The streak / rest-day logic is preserved bug-for-bug from the previous
-     * implementation: a missing day after a streak has started is silently skipped
-     * (the original loop did the same). Fixing the rest-day semantics is out of
-     * scope for this performance change.
-     */
-    private int calculateCurrentStreak(UUID userId) {
-        LocalDate today = LocalDate.now();
-        // 366 to safely cover the lookback window even if today's activity is in the
-        // future relative to the cutoff (timezone edge cases).
-        LocalDateTime since = today.minusDays(366).atStartOfDay();
-        Set<LocalDate> activityDates = new HashSet<>();
-        for (LocalDateTime ts : activityRepository.findActivityStartTimestampsSince(userId, since)) {
-            activityDates.add(ts.toLocalDate());
-        }
-
-        if (activityDates.isEmpty()) {
-            return 0;
-        }
-
-        LocalDate checkDate = today;
-        int streak = 0;
-
-        // Walk backwards from today using the in-memory set instead of per-day queries.
-        for (int i = 0; i < 365; i++) {
-            boolean hasActivity = activityDates.contains(checkDate);
-
-            if (hasActivity) {
-                streak++;
-                checkDate = checkDate.minusDays(1);
-            } else {
-                // Allow one rest day if we already have a streak (preserving original
-                // behaviour, including the latent "infinite consecutive rest days
-                // allowed once a streak has started" quirk in the original loop).
-                if (streak > 0 && i > 0) {
-                    checkDate = checkDate.minusDays(1);
-                    continue;
-                }
-                break;
-            }
-        }
-
-        return streak;
-    }
-
-    /**
      * Award an achievement to a user.
      */
     private Achievement awardAchievement(UUID userId, Achievement.AchievementType achievementType,
                                         String name, String description, String icon, String color,
-                                        UUID activityId, Map<String, Object> metadata) {
+                                        UUID activityId, LocalDateTime earnedAt,
+                                        Map<String, Object> metadata) {
         Achievement achievement = Achievement.builder()
                 .userId(userId)
                 .achievementType(achievementType)
@@ -471,7 +452,7 @@ public class AchievementService {
                 .description(description)
                 .badgeIcon(icon)
                 .badgeColor(color)
-                .earnedAt(LocalDateTime.now())
+                .earnedAt(earnedAt != null ? earnedAt : LocalDateTime.now())
                 .activityId(activityId)
                 .metadata(metadata)
                 .build();
@@ -509,5 +490,171 @@ public class AchievementService {
     @Transactional(readOnly = true)
     public long getAchievementCount(UUID userId) {
         return achievementRepository.countByUserId(userId);
+    }
+
+    private int calculateStreak(Set<LocalDate> activityDates, LocalDate anchorDate) {
+        if (activityDates.isEmpty() || !activityDates.contains(anchorDate)) {
+            return 0;
+        }
+
+        LocalDate checkDate = anchorDate;
+        int streak = 0;
+
+        for (int i = 0; i < 365; i++) {
+            boolean hasActivity = activityDates.contains(checkDate);
+
+            if (hasActivity) {
+                streak++;
+                checkDate = checkDate.minusDays(1);
+            } else {
+                if (streak > 0 && i > 0) {
+                    checkDate = checkDate.minusDays(1);
+                    continue;
+                }
+                break;
+            }
+        }
+
+        return streak;
+    }
+
+    private record ActivityProgress(
+            List<Activity> previousActivities,
+            List<Activity> currentActivities
+    ) {
+        private static ActivityProgress fromHistory(List<Activity> activityHistory, Activity currentActivity) {
+            int currentIndex = -1;
+            for (int i = 0; i < activityHistory.size(); i++) {
+                if (Objects.equals(activityHistory.get(i).getId(), currentActivity.getId())) {
+                    currentIndex = i;
+                    break;
+                }
+            }
+
+            if (currentIndex < 0) {
+                throw new IllegalStateException("Current activity missing from chronological history: " + currentActivity.getId());
+            }
+
+            return new ActivityProgress(
+                    List.copyOf(activityHistory.subList(0, currentIndex)),
+                    List.copyOf(activityHistory.subList(0, currentIndex + 1))
+            );
+        }
+
+        long previousActivityCount() {
+            return previousActivities.size();
+        }
+
+        long currentActivityCount() {
+            return currentActivities.size();
+        }
+
+        long previousActivityTypeCount(Activity.ActivityType type) {
+            return previousActivities.stream().filter(activity -> activity.getActivityType() == type).count();
+        }
+
+        long currentActivityTypeCount(Activity.ActivityType type) {
+            return currentActivities.stream().filter(activity -> activity.getActivityType() == type).count();
+        }
+
+        BigDecimal previousDistanceMeters() {
+            return sumDistance(previousActivities);
+        }
+
+        BigDecimal currentDistanceMeters() {
+            return sumDistance(currentActivities);
+        }
+
+        BigDecimal previousElevationMeters() {
+            return sumElevation(previousActivities);
+        }
+
+        BigDecimal currentElevationMeters() {
+            return sumElevation(currentActivities);
+        }
+
+        boolean previousHasElevationGainAtLeast(BigDecimal threshold) {
+            return previousActivities.stream()
+                    .map(Activity::getElevationGain)
+                    .filter(Objects::nonNull)
+                    .anyMatch(elevation -> elevation.compareTo(threshold) >= 0);
+        }
+
+        long previousDistinctActivityTypes() {
+            return previousActivities.stream().map(Activity::getActivityType).distinct().count();
+        }
+
+        long currentDistinctActivityTypes() {
+            return currentActivities.stream().map(Activity::getActivityType).distinct().count();
+        }
+
+        long previousActivitiesStartingBefore(LocalTime time) {
+            return previousActivities.stream()
+                    .filter(activity -> activity.getStartedAt() != null)
+                    .filter(activity -> activity.getStartedAt().toLocalTime().isBefore(time))
+                    .count();
+        }
+
+        long currentActivitiesStartingBefore(LocalTime time) {
+            return currentActivities.stream()
+                    .filter(activity -> activity.getStartedAt() != null)
+                    .filter(activity -> activity.getStartedAt().toLocalTime().isBefore(time))
+                    .count();
+        }
+
+        long previousActivitiesStartingAfter(LocalTime time) {
+            return previousActivities.stream()
+                    .filter(activity -> activity.getStartedAt() != null)
+                    .filter(activity -> activity.getStartedAt().toLocalTime().isAfter(time))
+                    .count();
+        }
+
+        long currentActivitiesStartingAfter(LocalTime time) {
+            return currentActivities.stream()
+                    .filter(activity -> activity.getStartedAt() != null)
+                    .filter(activity -> activity.getStartedAt().toLocalTime().isAfter(time))
+                    .count();
+        }
+
+        Set<LocalDate> previousActivityDates() {
+            return collectDates(previousActivities);
+        }
+
+        Set<LocalDate> currentActivityDates() {
+            return collectDates(currentActivities);
+        }
+
+        boolean previousHasMaxSpeedAtLeast(BigDecimal thresholdKmh) {
+            return previousActivities.stream()
+                    .map(Activity::getMetrics)
+                    .filter(Objects::nonNull)
+                    .map(metrics -> metrics.getMaxSpeed())
+                    .filter(Objects::nonNull)
+                    .anyMatch(speed -> speed.compareTo(thresholdKmh) >= 0);
+        }
+
+        private static BigDecimal sumDistance(List<Activity> activities) {
+            return activities.stream()
+                    .map(Activity::getTotalDistance)
+                    .filter(Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+        }
+
+        private static BigDecimal sumElevation(List<Activity> activities) {
+            return activities.stream()
+                    .map(Activity::getElevationGain)
+                    .filter(Objects::nonNull)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+        }
+
+        private static Set<LocalDate> collectDates(List<Activity> activities) {
+            Set<LocalDate> dates = new HashSet<>();
+            for (Activity activity : activities) {
+                if (activity.getStartedAt() != null) {
+                    dates.add(activity.getStartedAt().toLocalDate());
+                }
+            }
+            return dates;
+        }
     }
 }

--- a/src/main/java/net/javahippie/fitpub/service/AchievementService.java
+++ b/src/main/java/net/javahippie/fitpub/service/AchievementService.java
@@ -87,6 +87,31 @@ public class AchievementService {
     }
 
     /**
+     * Rebuild all achievements for a user from chronological activity history.
+     */
+    @Transactional
+    public List<Achievement> rebuildAchievementsForUser(UUID userId) {
+        if (userId == null) {
+            return List.of();
+        }
+
+        List<Activity> activityHistory = activityRepository.findByUserIdOrderByStartedAtAsc(userId);
+        if (activityHistory.isEmpty()) {
+            achievementRepository.deleteByUserId(userId);
+            return List.of();
+        }
+
+        achievementRepository.deleteByUserId(userId);
+
+        List<Achievement> rebuiltAchievements = new ArrayList<>();
+        for (Activity activity : activityHistory) {
+            rebuiltAchievements.addAll(checkAndAwardAchievements(activity));
+        }
+
+        return rebuiltAchievements;
+    }
+
+    /**
      * Check first activity achievements.
      */
     private List<Achievement> checkFirstActivityAchievements(UUID userId, Activity activity,

--- a/src/main/java/net/javahippie/fitpub/service/AchievementService.java
+++ b/src/main/java/net/javahippie/fitpub/service/AchievementService.java
@@ -109,10 +109,12 @@ public class AchievementService {
         List<Activity> activityHistory = activityRepository.findByUserIdOrderByStartedAtAsc(userId);
         if (activityHistory.isEmpty()) {
             achievementRepository.deleteByUserId(userId);
+            achievementRepository.flush();
             return List.of();
         }
 
         achievementRepository.deleteByUserId(userId);
+        achievementRepository.flush();
 
         Set<Achievement.AchievementType> existing = EnumSet.noneOf(Achievement.AchievementType.class);
         List<Achievement> rebuiltAchievements = new ArrayList<>();

--- a/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
@@ -7,6 +7,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 /**
  * Recalculates derived analytics after an activity has been deleted.
  */
@@ -17,14 +24,59 @@ public class ActivityDeleteRecalculationService {
 
     private final AchievementService achievementService;
     private final ActivitySummaryService activitySummaryService;
+    private final ConcurrentMap<UUID, PendingUserRecalculation> pendingRecalculations = new ConcurrentHashMap<>();
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleActivityDeleted(ActivityDeletedEvent event) {
-        achievementService.rebuildAchievementsForUser(event.userId());
-        activitySummaryService.updateWeeklySummary(event.userId(), event.activityDate());
-        activitySummaryService.updateMonthlySummary(event.userId(), event.activityDate());
-        activitySummaryService.updateYearlySummary(event.userId(), event.activityDate());
-        log.info("Recalculated achievements and summaries after deleting activity for user {}", event.userId());
+        PendingUserRecalculation pending = pendingRecalculations.computeIfAbsent(
+                event.userId(),
+                ignored -> new PendingUserRecalculation()
+        );
+
+        if (!pending.enqueueAndShouldStart(event.activityDate())) {
+            log.debug("Queued additional activity delete recalculation for user {}", event.userId());
+            return;
+        }
+
+        do {
+            Set<LocalDate> datesToRecalculate = pending.drainDates();
+            achievementService.rebuildAchievementsForUser(event.userId());
+            for (LocalDate date : datesToRecalculate) {
+                activitySummaryService.updateWeeklySummary(event.userId(), date);
+                activitySummaryService.updateMonthlySummary(event.userId(), date);
+                activitySummaryService.updateYearlySummary(event.userId(), date);
+            }
+        } while (pending.keepProcessing());
+
+        log.info("Recalculated achievements and summaries after deleting activities for user {}", event.userId());
+    }
+
+    private static final class PendingUserRecalculation {
+        private final Set<LocalDate> pendingDates = new HashSet<>();
+        private boolean processing;
+
+        synchronized boolean enqueueAndShouldStart(LocalDate activityDate) {
+            pendingDates.add(activityDate);
+            if (processing) {
+                return false;
+            }
+            processing = true;
+            return true;
+        }
+
+        synchronized Set<LocalDate> drainDates() {
+            Set<LocalDate> dates = new HashSet<>(pendingDates);
+            pendingDates.clear();
+            return dates;
+        }
+
+        synchronized boolean keepProcessing() {
+            if (pendingDates.isEmpty()) {
+                processing = false;
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
@@ -1,0 +1,30 @@
+package net.javahippie.fitpub.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Recalculates derived analytics after an activity has been deleted.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ActivityDeleteRecalculationService {
+
+    private final AchievementService achievementService;
+    private final ActivitySummaryService activitySummaryService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleActivityDeleted(ActivityDeletedEvent event) {
+        achievementService.rebuildAchievementsForUser(event.userId());
+        activitySummaryService.updateWeeklySummary(event.userId(), event.activityDate());
+        activitySummaryService.updateMonthlySummary(event.userId(), event.activityDate());
+        activitySummaryService.updateYearlySummary(event.userId(), event.activityDate());
+        log.info("Recalculated achievements and summaries after deleting activity for user {}", event.userId());
+    }
+}

--- a/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationService.java
@@ -24,6 +24,7 @@ public class ActivityDeleteRecalculationService {
 
     private final AchievementService achievementService;
     private final ActivitySummaryService activitySummaryService;
+    private final PersonalRecordService personalRecordService;
     private final ConcurrentMap<UUID, PendingUserRecalculation> pendingRecalculations = new ConcurrentHashMap<>();
 
     @Async
@@ -42,6 +43,7 @@ public class ActivityDeleteRecalculationService {
         do {
             Set<LocalDate> datesToRecalculate = pending.drainDates();
             achievementService.rebuildAchievementsForUser(event.userId());
+            personalRecordService.rebuildPersonalRecordsForUser(event.userId());
             for (LocalDate date : datesToRecalculate) {
                 activitySummaryService.updateWeeklySummary(event.userId(), date);
                 activitySummaryService.updateMonthlySummary(event.userId(), date);
@@ -49,7 +51,7 @@ public class ActivityDeleteRecalculationService {
             }
         } while (pending.keepProcessing());
 
-        log.info("Recalculated achievements and summaries after deleting activities for user {}", event.userId());
+        log.info("Recalculated achievements, personal records, and summaries after deleting activities for user {}", event.userId());
     }
 
     private static final class PendingUserRecalculation {

--- a/src/main/java/net/javahippie/fitpub/service/ActivityDeletedEvent.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivityDeletedEvent.java
@@ -1,0 +1,7 @@
+package net.javahippie.fitpub.service;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record ActivityDeletedEvent(UUID userId, LocalDate activityDate) {
+}

--- a/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
@@ -172,7 +172,7 @@ public class ActivitySummaryService {
                 startDateTime,
                 endDateTime
         );
-        long achievementsEarned = achievementRepository.countByUserIdAndDateRange(
+        long achievementsEarned = achievementRepository.countByUserIdAndActivityStartedDateRange(
                 userId,
                 startDateTime,
                 endDateTime

--- a/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
@@ -229,26 +229,67 @@ public class ActivitySummaryService {
     /**
      * Get current week summary.
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public ActivitySummary getCurrentWeekSummary(UUID userId) {
         LocalDate weekStart = LocalDate.now().with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
-        return activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+        LocalDate weekEndExclusive = weekStart.plusDays(7);
+        return getOrBuildCurrentSummary(
                 userId,
                 ActivitySummary.PeriodType.WEEK,
-                weekStart
-        ).orElse(null);
+                weekStart,
+                weekEndExclusive,
+                () -> updateWeeklySummary(userId, weekStart)
+        );
     }
 
     /**
      * Get current month summary.
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public ActivitySummary getCurrentMonthSummary(UUID userId) {
         LocalDate monthStart = LocalDate.now().with(TemporalAdjusters.firstDayOfMonth());
-        return activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+        LocalDate monthEndExclusive = monthStart.plusMonths(1);
+        return getOrBuildCurrentSummary(
                 userId,
                 ActivitySummary.PeriodType.MONTH,
-                monthStart
+                monthStart,
+                monthEndExclusive,
+                () -> updateMonthlySummary(userId, monthStart)
+        );
+    }
+
+    private ActivitySummary getOrBuildCurrentSummary(
+            UUID userId,
+            ActivitySummary.PeriodType periodType,
+            LocalDate periodStart,
+            LocalDate periodEndExclusive,
+            Runnable rebuildAction
+    ) {
+        ActivitySummary existingSummary = activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                periodType,
+                periodStart
+        ).orElse(null);
+
+        if (existingSummary != null) {
+            return existingSummary;
+        }
+
+        boolean hasActivitiesInPeriod = activityRepository.existsByUserIdAndStartedAtBetween(
+                userId,
+                periodStart.atStartOfDay(),
+                periodEndExclusive.atStartOfDay()
+        );
+
+        if (!hasActivitiesInPeriod) {
+            return null;
+        }
+
+        rebuildAction.run();
+        return activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                periodType,
+                periodStart
         ).orElse(null);
     }
 }

--- a/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
+++ b/src/main/java/net/javahippie/fitpub/service/ActivitySummaryService.java
@@ -258,6 +258,22 @@ public class ActivitySummaryService {
         );
     }
 
+    /**
+     * Get current year summary.
+     */
+    @Transactional
+    public ActivitySummary getCurrentYearSummary(UUID userId) {
+        LocalDate yearStart = LocalDate.now().with(TemporalAdjusters.firstDayOfYear());
+        LocalDate yearEndExclusive = yearStart.plusYears(1);
+        return getOrBuildCurrentSummary(
+                userId,
+                ActivitySummary.PeriodType.YEAR,
+                yearStart,
+                yearEndExclusive,
+                () -> updateYearlySummary(userId, yearStart)
+        );
+    }
+
     private ActivitySummary getOrBuildCurrentSummary(
             UUID userId,
             ActivitySummary.PeriodType periodType,
@@ -265,16 +281,6 @@ public class ActivitySummaryService {
             LocalDate periodEndExclusive,
             Runnable rebuildAction
     ) {
-        ActivitySummary existingSummary = activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
-                userId,
-                periodType,
-                periodStart
-        ).orElse(null);
-
-        if (existingSummary != null) {
-            return existingSummary;
-        }
-
         boolean hasActivitiesInPeriod = activityRepository.existsByUserIdAndStartedAtBetween(
                 userId,
                 periodStart.atStartOfDay(),
@@ -282,7 +288,11 @@ public class ActivitySummaryService {
         );
 
         if (!hasActivitiesInPeriod) {
-            return null;
+            return activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                    userId,
+                    periodType,
+                    periodStart
+            ).orElse(null);
         }
 
         rebuildAction.run();

--- a/src/main/java/net/javahippie/fitpub/service/BatchImportService.java
+++ b/src/main/java/net/javahippie/fitpub/service/BatchImportService.java
@@ -344,11 +344,9 @@ public class BatchImportService {
                 personalRecordService.checkAndUpdatePersonalRecords(activity);
             }
 
-            // Recalculate achievements for each activity
+            // Recalculate achievements from the full chronological activity history
             log.debug("Recalculating achievements...");
-            for (Activity activity : activities) {
-                achievementService.checkAndAwardAchievements(activity);
-            }
+            achievementService.rebuildAchievementsForUser(job.getUserId());
 
             // Recalculate training load for each activity
             log.debug("Recalculating training load...");

--- a/src/main/java/net/javahippie/fitpub/service/FitFileService.java
+++ b/src/main/java/net/javahippie/fitpub/service/FitFileService.java
@@ -18,6 +18,7 @@ import net.javahippie.fitpub.util.FitFileValidator;
 import net.javahippie.fitpub.util.FitParser;
 import net.javahippie.fitpub.util.ParsedActivityData;
 import net.javahippie.fitpub.util.TrackSimplifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -52,6 +53,7 @@ public class FitFileService {
     private final ActivitySummaryService activitySummaryService;
     private final WeatherService weatherService;
     private final HeatmapGridService heatmapGridService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * Processes an uploaded FIT file and creates an activity.
@@ -319,12 +321,10 @@ public class FitFileService {
         return activityRepository.findByIdAndUserId(activityId, userId)
             .map(activity -> {
                 activityRepository.delete(activity);
-                achievementService.rebuildAchievementsForUser(userId);
                 if (activity.getStartedAt() != null) {
-                    java.time.LocalDate activityDate = activity.getStartedAt().toLocalDate();
-                    activitySummaryService.updateWeeklySummary(userId, activityDate);
-                    activitySummaryService.updateMonthlySummary(userId, activityDate);
-                    activitySummaryService.updateYearlySummary(userId, activityDate);
+                    applicationEventPublisher.publishEvent(
+                        new ActivityDeletedEvent(userId, activity.getStartedAt().toLocalDate())
+                    );
                 }
                 log.info("Deleted activity {} for user {}", activityId, userId);
                 return true;

--- a/src/main/java/net/javahippie/fitpub/service/FitFileService.java
+++ b/src/main/java/net/javahippie/fitpub/service/FitFileService.java
@@ -320,6 +320,12 @@ public class FitFileService {
             .map(activity -> {
                 activityRepository.delete(activity);
                 achievementService.rebuildAchievementsForUser(userId);
+                if (activity.getStartedAt() != null) {
+                    java.time.LocalDate activityDate = activity.getStartedAt().toLocalDate();
+                    activitySummaryService.updateWeeklySummary(userId, activityDate);
+                    activitySummaryService.updateMonthlySummary(userId, activityDate);
+                    activitySummaryService.updateYearlySummary(userId, activityDate);
+                }
                 log.info("Deleted activity {} for user {}", activityId, userId);
                 return true;
             })

--- a/src/main/java/net/javahippie/fitpub/service/FitFileService.java
+++ b/src/main/java/net/javahippie/fitpub/service/FitFileService.java
@@ -319,6 +319,7 @@ public class FitFileService {
         return activityRepository.findByIdAndUserId(activityId, userId)
             .map(activity -> {
                 activityRepository.delete(activity);
+                achievementService.rebuildAchievementsForUser(userId);
                 log.info("Deleted activity {} for user {}", activityId, userId);
                 return true;
             })

--- a/src/main/java/net/javahippie/fitpub/service/PersonalRecordService.java
+++ b/src/main/java/net/javahippie/fitpub/service/PersonalRecordService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javahippie.fitpub.model.entity.Activity;
 import net.javahippie.fitpub.model.entity.PersonalRecord;
+import net.javahippie.fitpub.repository.ActivityRepository;
 import net.javahippie.fitpub.repository.PersonalRecordRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import java.util.UUID;
 @Slf4j
 public class PersonalRecordService {
 
+    private final ActivityRepository activityRepository;
     private final PersonalRecordRepository personalRecordRepository;
 
     /**
@@ -319,5 +321,20 @@ public class PersonalRecordService {
     @Transactional(readOnly = true)
     public long getPersonalRecordCount(UUID userId) {
         return personalRecordRepository.countByUserId(userId);
+    }
+
+    /**
+     * Rebuild all personal records for a user from remaining activities.
+     */
+    @Transactional
+    public void rebuildPersonalRecordsForUser(UUID userId) {
+        personalRecordRepository.deleteByUserId(userId);
+
+        List<Activity> activities = activityRepository.findByUserIdOrderByStartedAtAsc(userId);
+        for (Activity activity : activities) {
+            checkAndUpdatePersonalRecords(activity);
+        }
+
+        log.info("Rebuilt personal records for user {} from {} activities", userId, activities.size());
     }
 }

--- a/src/main/resources/templates/analytics/achievements.html
+++ b/src/main/resources/templates/analytics/achievements.html
@@ -8,15 +8,20 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <div class="container py-4">
-        <div class="d-flex justify-content-between align-items-center mb-4">
-            <h1>
-                <i class="bi bi-award-fill" style="color: var(--accent-orange);"></i> Achievements
-            </h1>
-            <a href="/analytics" class="btn btn-outline-primary">
-                <i class="bi bi-arrow-left"></i> Back to Dashboard
-            </a>
-        </div>
+        <div class="container py-4">
+            <div class="d-flex justify-content-between align-items-center mb-4">
+                <h1>
+                    <i class="bi bi-award-fill" style="color: var(--accent-orange);"></i> Achievements
+                </h1>
+                <div class="d-flex gap-2">
+                    <button id="rebuild-achievements-btn" type="button" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-repeat"></i> Recalculate
+                    </button>
+                    <a href="/analytics" class="btn btn-outline-primary">
+                        <i class="bi bi-arrow-left"></i> Back to Dashboard
+                    </a>
+                </div>
+            </div>
 
         <!-- Stats Summary -->
         <div class="row g-3 mb-4">
@@ -100,6 +105,35 @@
             }
         }
 
+        async function rebuildAchievements() {
+            const rebuildBtn = document.getElementById('rebuild-achievements-btn');
+            const originalContent = rebuildBtn.innerHTML;
+
+            rebuildBtn.disabled = true;
+            rebuildBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Recalculating...';
+
+            try {
+                const response = await FitPubAuth.authenticatedFetch('/api/analytics/achievements/rebuild', {
+                    method: 'POST'
+                });
+
+                const result = await response.json();
+
+                if (!response.ok) {
+                    throw new Error(result.message || 'Failed to recalculate achievements');
+                }
+
+                FitPub.showAlert('success', result.message || 'Achievements recalculated successfully');
+                await loadAchievements();
+            } catch (error) {
+                console.error('Error rebuilding achievements:', error);
+                FitPub.showAlert('danger', error.message || 'Failed to recalculate achievements');
+            } finally {
+                rebuildBtn.disabled = false;
+                rebuildBtn.innerHTML = originalContent;
+            }
+        }
+
         function updateStats(achievements) {
             // Earned count
             document.getElementById('earned-count').textContent = achievements.length;
@@ -108,6 +142,8 @@
             if (achievements.length > 0) {
                 const latest = new Date(achievements[0].earnedAt);
                 document.getElementById('latest-date').textContent = latest.toLocaleDateString();
+            } else {
+                document.getElementById('latest-date').textContent = '-';
             }
 
             // Completion percentage
@@ -217,6 +253,7 @@
                 window.location.href = '/auth/login';
                 return;
             }
+            document.getElementById('rebuild-achievements-btn').addEventListener('click', rebuildAchievements);
             loadAchievements();
         });
     </script>

--- a/src/main/resources/templates/analytics/achievements.html
+++ b/src/main/resources/templates/analytics/achievements.html
@@ -123,11 +123,11 @@
                     throw new Error(result.message || 'Failed to recalculate achievements');
                 }
 
-                FitPub.showAlert('success', result.message || 'Achievements recalculated successfully');
+                FitPub.showAlert(result.message || 'Achievements recalculated successfully', 'success');
                 await loadAchievements();
             } catch (error) {
                 console.error('Error rebuilding achievements:', error);
-                FitPub.showAlert('danger', error.message || 'Failed to recalculate achievements');
+                FitPub.showAlert(error.message || 'Failed to recalculate achievements', 'danger');
             } finally {
                 rebuildBtn.disabled = false;
                 rebuildBtn.innerHTML = originalContent;

--- a/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
@@ -415,6 +415,27 @@ class AchievementServiceTest {
     }
 
     @Test
+    @DisplayName("Should rebuild achievements from a stable history snapshot")
+    void testRebuildAchievementsForUser_UsesStableHistorySnapshot() {
+        Activity previous = createActivity(Activity.ActivityType.RUN, 9000L, BigDecimal.ZERO);
+        previous.setStartedAt(LocalDateTime.of(2025, 11, 30, 10, 0));
+        previous.setEndedAt(LocalDateTime.of(2025, 11, 30, 11, 0));
+        Activity activity = createActivity(Activity.ActivityType.RUN, 2000L, BigDecimal.ZERO);
+        activity.setStartedAt(LocalDateTime.of(2025, 12, 1, 7, 15));
+        activity.setEndedAt(LocalDateTime.of(2025, 12, 1, 8, 5));
+
+        when(activityRepository.findByUserIdOrderByStartedAtAsc(userId))
+                .thenReturn(List.of(previous, activity))
+                .thenReturn(List.of(previous));
+        when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<Achievement> rebuilt = achievementService.rebuildAchievementsForUser(userId);
+
+        assertTrue(rebuilt.stream().anyMatch(a -> a.getAchievementType() == Achievement.AchievementType.DISTANCE_10K));
+        verify(activityRepository, times(1)).findByUserIdOrderByStartedAtAsc(userId);
+    }
+
+    @Test
     @DisplayName("Should get user achievements")
     void testGetUserAchievements() {
         // Given

--- a/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -389,6 +390,28 @@ class AchievementServiceTest {
 
         assertEquals(activity.getEndedAt(), distanceAchievement.getEarnedAt());
         assertEquals(activity.getId(), distanceAchievement.getActivityId());
+    }
+
+    @Test
+    @DisplayName("Should rebuild achievements by deleting existing rows and replaying history")
+    void testRebuildAchievementsForUser() {
+        Activity previous = createActivity(Activity.ActivityType.RUN, 9000L, BigDecimal.ZERO);
+        previous.setStartedAt(LocalDateTime.of(2025, 11, 30, 10, 0));
+        previous.setEndedAt(LocalDateTime.of(2025, 11, 30, 11, 0));
+        Activity activity = createActivity(Activity.ActivityType.RUN, 2000L, BigDecimal.ZERO);
+        activity.setStartedAt(LocalDateTime.of(2025, 12, 1, 7, 15));
+        activity.setEndedAt(LocalDateTime.of(2025, 12, 1, 8, 5));
+
+        stubHistory(previous, activity);
+        when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<Achievement> rebuilt = achievementService.rebuildAchievementsForUser(userId);
+
+        assertTrue(rebuilt.stream().anyMatch(a -> a.getAchievementType() == Achievement.AchievementType.DISTANCE_10K));
+
+        InOrder inOrder = inOrder(achievementRepository);
+        inOrder.verify(achievementRepository).deleteByUserId(userId);
+        inOrder.verify(achievementRepository, atLeastOnce()).save(any(Achievement.class));
     }
 
     @Test

--- a/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
@@ -14,14 +14,14 @@ import net.javahippie.fitpub.repository.AchievementRepository;
 import net.javahippie.fitpub.repository.ActivityRepository;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -54,14 +54,7 @@ class AchievementServiceTest {
     void testCheckAndAwardAchievements_FirstActivity() {
         // Given
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
-
-        when(activityRepository.countByUserId(userId)).thenReturn(1L);
-        when(activityRepository.countByUserIdAndActivityType(userId, Activity.ActivityType.RUN)).thenReturn(1L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(5000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
-        // Streak source: today has one activity (1-day streak — not enough to trigger any streak achievement)
-        lenient().when(activityRepository.findActivityStartTimestampsSince(any(), any()))
-            .thenReturn(List.of(java.time.LocalDateTime.now()));
+        stubHistory(activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -82,12 +75,11 @@ class AchievementServiceTest {
     @DisplayName("Should award first run achievement")
     void testCheckAndAwardAchievements_FirstRun() {
         // Given
+        Activity firstRide = createActivity(Activity.ActivityType.RIDE, 10000L, BigDecimal.ZERO);
+        firstRide.setStartedAt(testTime.minusDays(1));
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(10L); // Not first overall
-        when(activityRepository.countByUserIdAndActivityType(userId, Activity.ActivityType.RUN)).thenReturn(1L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(50000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(2L);
+        stubHistory(firstRide, activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -102,13 +94,12 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award distance milestone achievements")
     void testCheckAndAwardAchievements_DistanceMilestone() {
-        // Given - User has completed 10+ km total
+        // Given - Current activity crosses 10 km total
+        Activity previous = createActivity(Activity.ActivityType.RUN, 7000L, BigDecimal.ZERO);
+        previous.setStartedAt(testTime.minusDays(1));
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(5L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(3L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(12000)); // 12 km
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
+        stubHistory(previous, activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -126,13 +117,17 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award activity count milestone")
     void testCheckAndAwardAchievements_ActivityCount() {
-        // Given - User has 10 activities
+        // Given - Current activity is the 10th activity
+        List<Activity> history = new ArrayList<>();
+        for (int i = 0; i < 9; i++) {
+            Activity previous = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+            previous.setStartedAt(testTime.minusDays(10 - i));
+            history.add(previous);
+        }
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+        history.add(activity);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(10L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(5L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(50000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
+        stubHistory(history);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -147,15 +142,18 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award early bird achievement")
     void testCheckAndAwardAchievements_EarlyBird() {
-        // Given - Activity before 6am, and user has 5+ early activities
+        // Given - Activity before 6am is the 5th early activity
+        List<Activity> history = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            Activity previous = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+            previous.setStartedAt(LocalDateTime.of(2025, 11, 20 + i, 5, 30));
+            history.add(previous);
+        }
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
         activity.setStartedAt(LocalDateTime.of(2025, 12, 1, 5, 30)); // 5:30 AM
 
-        when(activityRepository.countByUserId(userId)).thenReturn(10L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(5L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(50000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
-        when(activityRepository.countByUserIdAndStartTimeBefore(eq(userId), eq(LocalTime.of(6, 0)))).thenReturn(5L);
+        history.add(activity);
+        stubHistory(history);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -170,15 +168,18 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award night owl achievement")
     void testCheckAndAwardAchievements_NightOwl() {
-        // Given - Activity after 10pm, and user has 5+ late activities
+        // Given - Activity after 10pm is the 5th late activity
+        List<Activity> history = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            Activity previous = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+            previous.setStartedAt(LocalDateTime.of(2025, 11, 20 + i, 23, 0));
+            history.add(previous);
+        }
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
         activity.setStartedAt(LocalDateTime.of(2025, 12, 1, 23, 0)); // 11:00 PM
 
-        when(activityRepository.countByUserId(userId)).thenReturn(10L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(5L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(50000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
-        when(activityRepository.countByUserIdAndStartTimeAfter(eq(userId), eq(LocalTime.of(22, 0)))).thenReturn(5L);
+        history.add(activity);
+        stubHistory(history);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -196,11 +197,7 @@ class AchievementServiceTest {
         // Given - Activity with 1000m+ elevation gain
         Activity activity = createActivity(Activity.ActivityType.HIKE, 10000L, BigDecimal.valueOf(1200));
 
-        when(activityRepository.countByUserId(userId)).thenReturn(5L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(3L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(50000));
-        when(activityRepository.sumElevationGainByUserId(userId)).thenReturn(BigDecimal.valueOf(1200));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
+        stubHistory(activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -215,14 +212,12 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award total elevation milestones")
     void testCheckAndAwardAchievements_TotalElevation() {
-        // Given - User has 5000m+ total elevation
+        // Given - Current activity crosses 5000m total elevation
+        Activity previous = createActivity(Activity.ActivityType.HIKE, 10000L, BigDecimal.valueOf(4500));
+        previous.setStartedAt(testTime.minusDays(1));
         Activity activity = createActivity(Activity.ActivityType.HIKE, 10000L, BigDecimal.valueOf(500));
 
-        when(activityRepository.countByUserId(userId)).thenReturn(20L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(10L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(200000));
-        when(activityRepository.sumElevationGainByUserId(userId)).thenReturn(BigDecimal.valueOf(6000)); // 6000m total
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(2L);
+        stubHistory(previous, activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -240,13 +235,14 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award variety seeker achievement")
     void testCheckAndAwardAchievements_VarietySeeker() {
-        // Given - User has tried 3+ different activity types
+        // Given - Current activity introduces the 3rd distinct activity type
+        Activity run = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+        run.setStartedAt(testTime.minusDays(2));
+        Activity ride = createActivity(Activity.ActivityType.RIDE, 20000L, BigDecimal.ZERO);
+        ride.setStartedAt(testTime.minusDays(1));
         Activity activity = createActivity(Activity.ActivityType.SWIM, 2000L, BigDecimal.ZERO);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(15L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(5L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(30000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(3L);
+        stubHistory(run, ride, activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -267,10 +263,7 @@ class AchievementServiceTest {
         metrics.setMaxSpeed(BigDecimal.valueOf(45.0)); // 45 km/h (realistic for cycling)
         activity.setMetrics(metrics);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(10L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(5L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(200000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
+        stubHistory(activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -285,19 +278,18 @@ class AchievementServiceTest {
     @Test
     @DisplayName("Should award 7-day streak achievement")
     void testCheckAndAwardAchievements_7DayStreak() {
-        // Given - User has 7+ consecutive days of activities
+        // Given - Current activity completes a 7-day streak
+        List<Activity> history = new ArrayList<>();
+        LocalDate anchorDate = testTime.toLocalDate();
+        for (int i = 6; i >= 1; i--) {
+            Activity previous = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+            previous.setStartedAt(anchorDate.minusDays(i).atTime(10, 0));
+            history.add(previous);
+        }
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
+        history.add(activity);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(20L);
-        when(activityRepository.countByUserIdAndActivityType(any(), any())).thenReturn(10L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(100000));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
-        // Streak source: 8 consecutive days of activity ending today, as raw timestamps
-        java.time.LocalDateTime now = java.time.LocalDateTime.now();
-        when(activityRepository.findActivityStartTimestampsSince(any(), any())).thenReturn(List.of(
-            now, now.minusDays(1), now.minusDays(2), now.minusDays(3),
-            now.minusDays(4), now.minusDays(5), now.minusDays(6), now.minusDays(7)
-        ));
+        stubHistory(history);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -314,8 +306,7 @@ class AchievementServiceTest {
     void testCheckAndAwardAchievements_AlreadyEarned() {
         // Given - User already has every achievement
         Activity activity = createActivity(Activity.ActivityType.RUN, 5000L, BigDecimal.ZERO);
-
-        when(activityRepository.countByUserId(userId)).thenReturn(10L);
+        stubHistory(activity);
         // Simulate "user already has all achievements" by returning one of every type from the
         // preload query that checkAndAwardAchievements uses to populate the in-memory set.
         List<Achievement> allEarned = new java.util.ArrayList<>();
@@ -359,11 +350,7 @@ class AchievementServiceTest {
         metrics.setMaxSpeed(BigDecimal.valueOf(16.0)); // 57.6 km/h (unrealistic for run, but for testing)
         activity.setMetrics(metrics);
 
-        when(activityRepository.countByUserId(userId)).thenReturn(1L); // First activity
-        when(activityRepository.countByUserIdAndActivityType(userId, Activity.ActivityType.RUN)).thenReturn(1L);
-        when(activityRepository.sumDistanceByUserId(userId)).thenReturn(BigDecimal.valueOf(5000));
-        when(activityRepository.sumElevationGainByUserId(userId)).thenReturn(BigDecimal.valueOf(1100));
-        when(activityRepository.countDistinctActivityTypesByUserId(userId)).thenReturn(1L);
+        stubHistory(activity);
         when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
@@ -378,6 +365,30 @@ class AchievementServiceTest {
         assertTrue(achievements.stream().anyMatch(a ->
             a.getAchievementType() == Achievement.AchievementType.MOUNTAINEER_1000M
         ));
+    }
+
+    @Test
+    @DisplayName("Should use activity end time as earnedAt for historical milestone")
+    void testCheckAndAwardAchievements_UsesActivityEndTimeForEarnedAt() {
+        Activity previous = createActivity(Activity.ActivityType.RUN, 9000L, BigDecimal.ZERO);
+        previous.setStartedAt(LocalDateTime.of(2025, 11, 30, 10, 0));
+        previous.setEndedAt(LocalDateTime.of(2025, 11, 30, 11, 0));
+        Activity activity = createActivity(Activity.ActivityType.RUN, 2000L, BigDecimal.ZERO);
+        activity.setStartedAt(LocalDateTime.of(2025, 12, 1, 7, 15));
+        activity.setEndedAt(LocalDateTime.of(2025, 12, 1, 8, 5));
+
+        stubHistory(previous, activity);
+        when(achievementRepository.save(any(Achievement.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<Achievement> achievements = achievementService.checkAndAwardAchievements(activity);
+
+        Achievement distanceAchievement = achievements.stream()
+                .filter(a -> a.getAchievementType() == Achievement.AchievementType.DISTANCE_10K)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(activity.getEndedAt(), distanceAchievement.getEarnedAt());
+        assertEquals(activity.getId(), distanceAchievement.getActivityId());
     }
 
     @Test
@@ -421,6 +432,7 @@ class AchievementServiceTest {
                 .userId(userId)
                 .activityType(activityType)
                 .startedAt(testTime)
+                .endedAt(testTime.plusHours(1))
                 .totalDistance(BigDecimal.valueOf(distanceMeters))
                 .totalDurationSeconds(3600L)
                 .elevationGain(elevationGain)
@@ -438,5 +450,13 @@ class AchievementServiceTest {
                 .badgeColor("#ff00ff")
                 .earnedAt(testTime)
                 .build();
+    }
+
+    private void stubHistory(Activity... activities) {
+        stubHistory(List.of(activities));
+    }
+
+    private void stubHistory(List<Activity> activities) {
+        when(activityRepository.findByUserIdOrderByStartedAtAsc(userId)).thenReturn(activities);
     }
 }

--- a/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/AchievementServiceTest.java
@@ -411,6 +411,7 @@ class AchievementServiceTest {
 
         InOrder inOrder = inOrder(achievementRepository);
         inOrder.verify(achievementRepository).deleteByUserId(userId);
+        inOrder.verify(achievementRepository).flush();
         inOrder.verify(achievementRepository, atLeastOnce()).save(any(Achievement.class));
     }
 

--- a/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
@@ -9,7 +9,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,5 +39,31 @@ class ActivityDeleteRecalculationServiceTest {
         verify(activitySummaryService).updateWeeklySummary(userId, activityDate);
         verify(activitySummaryService).updateMonthlySummary(userId, activityDate);
         verify(activitySummaryService).updateYearlySummary(userId, activityDate);
+    }
+
+    @Test
+    @DisplayName("Should serialize recalculations per user and replay queued deletions")
+    void shouldSerializeRecalculationsPerUserAndReplayQueuedDeletions() {
+        UUID userId = UUID.randomUUID();
+        LocalDate firstDate = LocalDate.of(2025, 12, 3);
+        LocalDate secondDate = LocalDate.of(2025, 12, 4);
+        AtomicBoolean queuedSecondDelete = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            if (queuedSecondDelete.compareAndSet(false, true)) {
+                activityDeleteRecalculationService.handleActivityDeleted(new ActivityDeletedEvent(userId, secondDate));
+            }
+            return null;
+        }).when(achievementService).rebuildAchievementsForUser(userId);
+
+        activityDeleteRecalculationService.handleActivityDeleted(new ActivityDeletedEvent(userId, firstDate));
+
+        verify(achievementService, times(2)).rebuildAchievementsForUser(userId);
+        verify(activitySummaryService).updateWeeklySummary(userId, firstDate);
+        verify(activitySummaryService).updateMonthlySummary(userId, firstDate);
+        verify(activitySummaryService).updateYearlySummary(userId, firstDate);
+        verify(activitySummaryService).updateWeeklySummary(userId, secondDate);
+        verify(activitySummaryService).updateMonthlySummary(userId, secondDate);
+        verify(activitySummaryService).updateYearlySummary(userId, secondDate);
     }
 }

--- a/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
@@ -1,0 +1,40 @@
+package net.javahippie.fitpub.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityDeleteRecalculationServiceTest {
+
+    @Mock
+    private AchievementService achievementService;
+
+    @Mock
+    private ActivitySummaryService activitySummaryService;
+
+    @InjectMocks
+    private ActivityDeleteRecalculationService activityDeleteRecalculationService;
+
+    @Test
+    @DisplayName("Should rebuild achievements and summaries after activity deletion")
+    void shouldRebuildAchievementsAndSummariesAfterActivityDeletion() {
+        UUID userId = UUID.randomUUID();
+        LocalDate activityDate = LocalDate.of(2025, 12, 3);
+
+        activityDeleteRecalculationService.handleActivityDeleted(new ActivityDeletedEvent(userId, activityDate));
+
+        verify(achievementService).rebuildAchievementsForUser(userId);
+        verify(activitySummaryService).updateWeeklySummary(userId, activityDate);
+        verify(activitySummaryService).updateMonthlySummary(userId, activityDate);
+        verify(activitySummaryService).updateYearlySummary(userId, activityDate);
+    }
+}

--- a/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivityDeleteRecalculationServiceTest.java
@@ -24,6 +24,9 @@ class ActivityDeleteRecalculationServiceTest {
     @Mock
     private ActivitySummaryService activitySummaryService;
 
+    @Mock
+    private PersonalRecordService personalRecordService;
+
     @InjectMocks
     private ActivityDeleteRecalculationService activityDeleteRecalculationService;
 
@@ -36,6 +39,7 @@ class ActivityDeleteRecalculationServiceTest {
         activityDeleteRecalculationService.handleActivityDeleted(new ActivityDeletedEvent(userId, activityDate));
 
         verify(achievementService).rebuildAchievementsForUser(userId);
+        verify(personalRecordService).rebuildPersonalRecordsForUser(userId);
         verify(activitySummaryService).updateWeeklySummary(userId, activityDate);
         verify(activitySummaryService).updateMonthlySummary(userId, activityDate);
         verify(activitySummaryService).updateYearlySummary(userId, activityDate);
@@ -59,6 +63,7 @@ class ActivityDeleteRecalculationServiceTest {
         activityDeleteRecalculationService.handleActivityDeleted(new ActivityDeletedEvent(userId, firstDate));
 
         verify(achievementService, times(2)).rebuildAchievementsForUser(userId);
+        verify(personalRecordService, times(2)).rebuildPersonalRecordsForUser(userId);
         verify(activitySummaryService).updateWeeklySummary(userId, firstDate);
         verify(activitySummaryService).updateMonthlySummary(userId, firstDate);
         verify(activitySummaryService).updateYearlySummary(userId, firstDate);

--- a/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
@@ -162,4 +162,116 @@ class ActivitySummaryServiceTest {
         assertNull(result);
         verify(activityRepository).existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime);
     }
+
+    @Test
+    @DisplayName("Should rebuild stale current month summary when activities exist")
+    void getCurrentMonthSummary_RebuildsExistingStaleSummary() {
+        LocalDate monthStart = LocalDate.now().withDayOfMonth(1);
+        LocalDateTime startDateTime = monthStart.atStartOfDay();
+        LocalDateTime endDateTime = monthStart.plusMonths(1).atStartOfDay();
+
+        Activity activity = Activity.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .activityType(Activity.ActivityType.RUN)
+                .startedAt(startDateTime.plusDays(3).plusHours(6))
+                .endedAt(startDateTime.plusDays(3).plusHours(7))
+                .totalDistance(BigDecimal.valueOf(12000))
+                .totalDurationSeconds(4200L)
+                .elevationGain(BigDecimal.valueOf(200))
+                .build();
+
+        ActivitySummary rebuiltSummary = ActivitySummary.builder()
+                .userId(userId)
+                .periodType(ActivitySummary.PeriodType.MONTH)
+                .periodStart(monthStart)
+                .periodEnd(monthStart.plusMonths(1).minusDays(1))
+                .activityCount(1)
+                .build();
+
+        when(activityRepository.existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime))
+                .thenReturn(true);
+        when(activityRepository.findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(userId, startDateTime, endDateTime))
+                .thenReturn(List.of(activity));
+        when(personalRecordRepository.countByUserIdAndDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(achievementRepository.countByUserIdAndActivityStartedDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                ActivitySummary.PeriodType.MONTH,
+                monthStart
+        )).thenReturn(
+                Optional.of(ActivitySummary.builder()
+                        .userId(userId)
+                        .periodType(ActivitySummary.PeriodType.MONTH)
+                        .periodStart(monthStart)
+                        .periodEnd(monthStart.plusMonths(1).minusDays(1))
+                        .activityCount(0)
+                        .build()),
+                Optional.of(rebuiltSummary)
+        );
+        when(activitySummaryRepository.save(org.mockito.ArgumentMatchers.any(ActivitySummary.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivitySummary result = activitySummaryService.getCurrentMonthSummary(userId);
+
+        assertNotNull(result);
+        assertEquals(1, result.getActivityCount());
+        verify(activitySummaryRepository).save(org.mockito.ArgumentMatchers.any(ActivitySummary.class));
+    }
+
+    @Test
+    @DisplayName("Should rebuild stale current year summary when activities exist")
+    void getCurrentYearSummary_RebuildsExistingStaleSummary() {
+        LocalDate yearStart = LocalDate.now().withDayOfYear(1);
+        LocalDateTime startDateTime = yearStart.atStartOfDay();
+        LocalDateTime endDateTime = yearStart.plusYears(1).atStartOfDay();
+
+        Activity activity = Activity.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .activityType(Activity.ActivityType.RIDE)
+                .startedAt(startDateTime.plusDays(20).plusHours(9))
+                .endedAt(startDateTime.plusDays(20).plusHours(11))
+                .totalDistance(BigDecimal.valueOf(65000))
+                .totalDurationSeconds(7200L)
+                .elevationGain(BigDecimal.valueOf(900))
+                .build();
+
+        ActivitySummary rebuiltSummary = ActivitySummary.builder()
+                .userId(userId)
+                .periodType(ActivitySummary.PeriodType.YEAR)
+                .periodStart(yearStart)
+                .periodEnd(yearStart.plusYears(1).minusDays(1))
+                .activityCount(1)
+                .build();
+
+        when(activityRepository.existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime))
+                .thenReturn(true);
+        when(activityRepository.findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(userId, startDateTime, endDateTime))
+                .thenReturn(List.of(activity));
+        when(personalRecordRepository.countByUserIdAndDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(achievementRepository.countByUserIdAndActivityStartedDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                ActivitySummary.PeriodType.YEAR,
+                yearStart
+        )).thenReturn(
+                Optional.of(ActivitySummary.builder()
+                        .userId(userId)
+                        .periodType(ActivitySummary.PeriodType.YEAR)
+                        .periodStart(yearStart)
+                        .periodEnd(yearStart.plusYears(1).minusDays(1))
+                        .activityCount(0)
+                        .build()),
+                Optional.of(rebuiltSummary)
+        );
+        when(activitySummaryRepository.save(org.mockito.ArgumentMatchers.any(ActivitySummary.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivitySummary result = activitySummaryService.getCurrentYearSummary(userId);
+
+        assertNotNull(result);
+        assertEquals(1, result.getActivityCount());
+        verify(activitySummaryRepository).save(org.mockito.ArgumentMatchers.any(ActivitySummary.class));
+    }
 }

--- a/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,5 +93,73 @@ class ActivitySummaryServiceTest {
                 summary.getAchievementsEarned() == 1 &&
                 summary.getActivityCount() == 1
         ));
+    }
+
+    @Test
+    @DisplayName("Should rebuild current month summary on demand when activities exist but summary is missing")
+    void getCurrentMonthSummary_RebuildsMissingSummary() {
+        LocalDate monthStart = LocalDate.now().withDayOfMonth(1);
+        LocalDateTime startDateTime = monthStart.atStartOfDay();
+        LocalDateTime endDateTime = monthStart.plusMonths(1).atStartOfDay();
+
+        Activity activity = Activity.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .activityType(Activity.ActivityType.RUN)
+                .startedAt(startDateTime.plusDays(2).plusHours(7))
+                .endedAt(startDateTime.plusDays(2).plusHours(8))
+                .totalDistance(BigDecimal.valueOf(10000))
+                .totalDurationSeconds(3600L)
+                .elevationGain(BigDecimal.valueOf(150))
+                .build();
+
+        ActivitySummary rebuiltSummary = ActivitySummary.builder()
+                .userId(userId)
+                .periodType(ActivitySummary.PeriodType.MONTH)
+                .periodStart(monthStart)
+                .periodEnd(monthStart.plusMonths(1).minusDays(1))
+                .activityCount(1)
+                .build();
+
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                ActivitySummary.PeriodType.MONTH,
+                monthStart
+        )).thenReturn(Optional.empty(), Optional.of(rebuiltSummary));
+        when(activityRepository.existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime))
+                .thenReturn(true);
+        when(activityRepository.findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(userId, startDateTime, endDateTime))
+                .thenReturn(List.of(activity));
+        when(personalRecordRepository.countByUserIdAndDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(achievementRepository.countByUserIdAndActivityStartedDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(activitySummaryRepository.save(org.mockito.ArgumentMatchers.any(ActivitySummary.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ActivitySummary result = activitySummaryService.getCurrentMonthSummary(userId);
+
+        assertNotNull(result);
+        assertEquals(1, result.getActivityCount());
+        verify(activityRepository).existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime);
+    }
+
+    @Test
+    @DisplayName("Should return null for current month summary when no activities exist in the period")
+    void getCurrentMonthSummary_ReturnsNullWhenNoActivitiesExist() {
+        LocalDate monthStart = LocalDate.now().withDayOfMonth(1);
+        LocalDateTime startDateTime = monthStart.atStartOfDay();
+        LocalDateTime endDateTime = monthStart.plusMonths(1).atStartOfDay();
+
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                ActivitySummary.PeriodType.MONTH,
+                monthStart
+        )).thenReturn(Optional.empty());
+        when(activityRepository.existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime))
+                .thenReturn(false);
+
+        ActivitySummary result = activitySummaryService.getCurrentMonthSummary(userId);
+
+        assertNull(result);
+        verify(activityRepository).existsByUserIdAndStartedAtBetween(userId, startDateTime, endDateTime);
     }
 }

--- a/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivitySummaryServiceTest.java
@@ -1,0 +1,95 @@
+package net.javahippie.fitpub.service;
+
+import net.javahippie.fitpub.model.entity.Activity;
+import net.javahippie.fitpub.model.entity.ActivitySummary;
+import net.javahippie.fitpub.repository.ActivityRepository;
+import net.javahippie.fitpub.repository.ActivitySummaryRepository;
+import net.javahippie.fitpub.repository.AchievementRepository;
+import net.javahippie.fitpub.repository.PersonalRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ActivitySummaryServiceTest {
+
+    @Mock
+    private ActivitySummaryRepository activitySummaryRepository;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private PersonalRecordRepository personalRecordRepository;
+
+    @Mock
+    private AchievementRepository achievementRepository;
+
+    @InjectMocks
+    private ActivitySummaryService activitySummaryService;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("Should count achievements in summaries by triggering activity start date")
+    void testUpdateWeeklySummary_CountsAchievementsByActivityStartDate() {
+        LocalDate weekDate = LocalDate.of(2025, 12, 3);
+        LocalDate weekStart = LocalDate.of(2025, 12, 1);
+        LocalDateTime startDateTime = weekStart.atStartOfDay();
+        LocalDateTime endDateTime = weekStart.plusDays(7).atStartOfDay();
+
+        Activity activity = Activity.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .activityType(Activity.ActivityType.RUN)
+                .startedAt(LocalDateTime.of(2025, 12, 3, 23, 30))
+                .endedAt(LocalDateTime.of(2025, 12, 4, 0, 15))
+                .totalDistance(BigDecimal.valueOf(5000))
+                .totalDurationSeconds(2700L)
+                .elevationGain(BigDecimal.valueOf(120))
+                .build();
+
+        when(activitySummaryRepository.findByUserIdAndPeriodTypeAndPeriodStart(
+                userId,
+                ActivitySummary.PeriodType.WEEK,
+                weekStart
+        )).thenReturn(Optional.empty());
+        when(activityRepository.findByUserIdAndStartedAtBetweenOrderByStartedAtDesc(
+                userId,
+                startDateTime,
+                endDateTime
+        )).thenReturn(List.of(activity));
+        when(personalRecordRepository.countByUserIdAndDateRange(userId, startDateTime, endDateTime)).thenReturn(0L);
+        when(achievementRepository.countByUserIdAndActivityStartedDateRange(userId, startDateTime, endDateTime)).thenReturn(1L);
+        when(activitySummaryRepository.save(org.mockito.ArgumentMatchers.any(ActivitySummary.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        activitySummaryService.updateWeeklySummary(userId, weekDate);
+
+        verify(achievementRepository).countByUserIdAndActivityStartedDateRange(userId, startDateTime, endDateTime);
+        verify(activitySummaryRepository).save(org.mockito.ArgumentMatchers.argThat(summary ->
+                summary.getAchievementsEarned() == 1 &&
+                summary.getActivityCount() == 1
+        ));
+    }
+}

--- a/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
@@ -21,6 +21,7 @@ import net.javahippie.fitpub.util.FitFileValidator;
 import net.javahippie.fitpub.util.FitParser;
 import net.javahippie.fitpub.util.ParsedActivityData;
 import net.javahippie.fitpub.util.TrackSimplifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.math.BigDecimal;
@@ -73,6 +74,9 @@ class FitFileServiceTest {
 
     @Mock
     private HeatmapGridService heatmapGridService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @Spy
     private ObjectMapper objectMapper;
@@ -240,10 +244,10 @@ class FitFileServiceTest {
         // Assert
         assertTrue(result);
         verify(activityRepository).delete(activity);
-        verify(achievementService).rebuildAchievementsForUser(testUserId);
-        verify(activitySummaryService).updateWeeklySummary(testUserId, startedAt.toLocalDate());
-        verify(activitySummaryService).updateMonthlySummary(testUserId, startedAt.toLocalDate());
-        verify(activitySummaryService).updateYearlySummary(testUserId, startedAt.toLocalDate());
+        ArgumentCaptor<ActivityDeletedEvent> eventCaptor = ArgumentCaptor.forClass(ActivityDeletedEvent.class);
+        verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+        assertEquals(testUserId, eventCaptor.getValue().userId());
+        assertEquals(startedAt.toLocalDate(), eventCaptor.getValue().activityDate());
     }
 
     @Test
@@ -260,10 +264,7 @@ class FitFileServiceTest {
         // Assert
         assertFalse(result);
         verify(activityRepository, never()).delete(any());
-        verify(achievementService, never()).rebuildAchievementsForUser(any());
-        verify(activitySummaryService, never()).updateWeeklySummary(any(), any());
-        verify(activitySummaryService, never()).updateMonthlySummary(any(), any());
-        verify(activitySummaryService, never()).updateYearlySummary(any(), any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
     }
 
     @Test

--- a/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
@@ -224,9 +224,11 @@ class FitFileServiceTest {
     void testDeleteActivity() {
         // Arrange
         UUID activityId = UUID.randomUUID();
+        LocalDateTime startedAt = LocalDateTime.of(2025, 12, 3, 10, 0);
         Activity activity = Activity.builder()
             .id(activityId)
             .userId(testUserId)
+            .startedAt(startedAt)
             .build();
 
         when(activityRepository.findByIdAndUserId(activityId, testUserId))
@@ -239,6 +241,9 @@ class FitFileServiceTest {
         assertTrue(result);
         verify(activityRepository).delete(activity);
         verify(achievementService).rebuildAchievementsForUser(testUserId);
+        verify(activitySummaryService).updateWeeklySummary(testUserId, startedAt.toLocalDate());
+        verify(activitySummaryService).updateMonthlySummary(testUserId, startedAt.toLocalDate());
+        verify(activitySummaryService).updateYearlySummary(testUserId, startedAt.toLocalDate());
     }
 
     @Test
@@ -256,6 +261,9 @@ class FitFileServiceTest {
         assertFalse(result);
         verify(activityRepository, never()).delete(any());
         verify(achievementService, never()).rebuildAchievementsForUser(any());
+        verify(activitySummaryService, never()).updateWeeklySummary(any(), any());
+        verify(activitySummaryService, never()).updateMonthlySummary(any(), any());
+        verify(activitySummaryService, never()).updateYearlySummary(any(), any());
     }
 
     @Test

--- a/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/FitFileServiceTest.java
@@ -238,6 +238,7 @@ class FitFileServiceTest {
         // Assert
         assertTrue(result);
         verify(activityRepository).delete(activity);
+        verify(achievementService).rebuildAchievementsForUser(testUserId);
     }
 
     @Test
@@ -254,6 +255,7 @@ class FitFileServiceTest {
         // Assert
         assertFalse(result);
         verify(activityRepository, never()).delete(any());
+        verify(achievementService, never()).rebuildAchievementsForUser(any());
     }
 
     @Test

--- a/src/test/java/net/javahippie/fitpub/service/PersonalRecordServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/PersonalRecordServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import net.javahippie.fitpub.model.entity.Activity;
 import net.javahippie.fitpub.model.entity.ActivityMetrics;
 import net.javahippie.fitpub.model.entity.PersonalRecord;
+import net.javahippie.fitpub.repository.ActivityRepository;
 import net.javahippie.fitpub.repository.PersonalRecordRepository;
 
 import java.math.BigDecimal;
@@ -32,6 +33,9 @@ class PersonalRecordServiceTest {
 
     @Mock
     private PersonalRecordRepository personalRecordRepository;
+
+    @Mock
+    private ActivityRepository activityRepository;
 
     @InjectMocks
     private PersonalRecordService personalRecordService;
@@ -413,6 +417,37 @@ class PersonalRecordServiceTest {
         assertTrue(records.stream().anyMatch(r ->
             r.getRecordType() == PersonalRecord.RecordType.HIGHEST_ELEVATION_GAIN
         ));
+    }
+
+    @Test
+    @DisplayName("Should rebuild personal records from remaining activities")
+    void testRebuildPersonalRecordsForUser() {
+        Activity firstActivity = createActivity(
+                10000L,
+                3600L,
+                BigDecimal.valueOf(100)
+        );
+        firstActivity.setStartedAt(testTime.minusDays(2));
+
+        Activity secondActivity = createActivity(
+                15000L,
+                4500L,
+                BigDecimal.valueOf(200)
+        );
+        secondActivity.setStartedAt(testTime.minusDays(1));
+
+        when(activityRepository.findByUserIdOrderByStartedAtAsc(userId))
+                .thenReturn(List.of(firstActivity, secondActivity));
+        when(personalRecordRepository.findByUserIdAndActivityTypeAndRecordType(any(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(personalRecordRepository.save(any(PersonalRecord.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        personalRecordService.rebuildPersonalRecordsForUser(userId);
+
+        verify(personalRecordRepository).deleteByUserId(userId);
+        verify(activityRepository).findByUserIdOrderByStartedAtAsc(userId);
+        verify(personalRecordRepository, atLeastOnce()).save(any(PersonalRecord.class));
     }
 
     // Helper methods


### PR DESCRIPTION
## Description

This PR fixes incorrect achievement dates in analytics and tightens up related rebuild behavior.

### Why

Achievements were shown with the time they were awarded or uploaded instead of the time of the activity that actually triggered them. That made the achievement history misleading, especially for historical imports and recalculations. In addition, deleting activities could leave achievements and summary data out of sync.

### What changed

- `earnedAt` for achievements now uses the triggering activity time instead of the upload/award time.
- Achievement detection was adjusted so milestone-style achievements are tied to the actual activity that crossed the threshold.
- Added a rebuild path that recalculates all achievements for a user from activity history.
- Batch recalculation now rebuilds achievements from history instead of incrementally re-awarding them.
- Deleting an activity now also refreshes achievements and affected summaries.
- Summary achievement counts now use the linked activity period instead of `earnedAt`, which avoids period mismatches.
- Added a manual “Recalculate” action on the achievements page for recovery if data gets out of sync.

### Result

Achievement dates and links are now aligned with the activity that actually earned them, and analytics stays consistent after imports, rebuilds, and deletions.