### PR TITLE
Fix test errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <jjwt.version>0.12.3</jjwt.version>
-        <testcontainers.version>2.0.3</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -170,15 +170,14 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-junit-jupiter</artifactId>
-            <version>2.0.2</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
-            <version>2.0.1</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/javahippie/fitpub/util/ActivityFormatter.java
+++ b/src/main/java/net/javahippie/fitpub/util/ActivityFormatter.java
@@ -98,6 +98,10 @@ public class ActivityFormatter {
      *
      */
     private static LocalDateTime getUtcDateTimeInZone(LocalDateTime utcDateTime, String timezone) {
+        if (timezone == null || timezone.isBlank()) {
+            return utcDateTime;
+        }
+
         try {
             return utcDateTime.atZone(ZoneOffset.UTC)
                     .withZoneSameInstant(ZoneId.of(timezone))

--- a/src/test/java/net/javahippie/fitpub/config/TestcontainersConfiguration.java
+++ b/src/test/java/net/javahippie/fitpub/config/TestcontainersConfiguration.java
@@ -4,7 +4,6 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -23,8 +22,6 @@ public class TestcontainersConfiguration {
         )
                 .withDatabaseName("testdb")
                 .withUsername("test")
-                .withPassword("test")
-                .waitingFor(new HostPortWaitStrategy())
-                .withReuse(true);
+                .withPassword("test");
     }
 }

--- a/src/test/java/net/javahippie/fitpub/service/ActivityImageServiceTest.java
+++ b/src/test/java/net/javahippie/fitpub/service/ActivityImageServiceTest.java
@@ -27,12 +27,16 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Manual test for ActivityImageService.
  * These tests are disabled by default and should only be run manually.
+ *
+ * To run this test manually:
+ * mvn test -Dtest=ActivityImageServiceTest
  */
 @SpringBootTest(properties = {
         "fitpub.image.osm-tiles.enabled=true"
 })
 @ActiveProfiles("test")
 @Import(TestcontainersConfiguration.class)
+@Disabled("Manual test - run explicitly when needed")
 class ActivityImageServiceTest {
 
     @Autowired
@@ -55,7 +59,6 @@ class ActivityImageServiceTest {
      * mvn test -Dtest=ActivityImageServiceTest#testGenerateActivityImage_Manual
      */
     @Test
-    @Disabled("Manual test - run explicitly when needed")
     @DisplayName("Generate activity image from test FIT file")
     void testGenerateActivityImage_Manual() throws Exception {
         // Load test FIT file


### PR DESCRIPTION
While running the tests, I noticed a few issues:

- Mixing of TestContainers versions (2.0.1, 2.0.2, and 2.0.3)
- Enabling Reuse, even though it is not supported and prone to errors (warning in the log)
- Explicitly setting the `HostPortWaitStrategy` (the container sets one itself)
- Unnecessary setup of the test context for a test class with disabled (manual) tests
- One test exposed a potential `NullPointerException` in the production code