### PR TITLE
fix(analytics): show highest elevation gain in meters

### DIFF
--- a/src/main/resources/templates/analytics/dashboard.html
+++ b/src/main/resources/templates/analytics/dashboard.html
@@ -317,6 +317,9 @@
                 }
                 return `${minutes}:${seconds.toString().padStart(2, '0')}`;
             } else if (unit === 'meters') {
+                if (type === 'HIGHEST_ELEVATION_GAIN') {
+                    return `${Math.round(value)} m`;
+                }
                 return `${(value / 1000).toFixed(2)} km`;
             } else if (unit === 'mps') {
                 return `${(value * 3.6).toFixed(2)} km/h`;

--- a/src/main/resources/templates/analytics/personal-records.html
+++ b/src/main/resources/templates/analytics/personal-records.html
@@ -202,6 +202,9 @@
                 }
                 return `${minutes}:${seconds.toString().padStart(2, '0')}`;
             } else if (unit === 'meters') {
+                if (type === 'HIGHEST_ELEVATION_GAIN') {
+                    return `${Math.round(value)} m`;
+                }
                 return `${(value / 1000).toFixed(2)} km`;
             } else if (unit === 'mps') {
                 return `${(value * 3.6).toFixed(2)} km/h`;
@@ -226,6 +229,9 @@
                 const diff = current - previous;
                 const percentImprove = (diff / previous * 100).toFixed(1);
                 if (pr.unit === 'meters') {
+                    if (pr.recordType === 'HIGHEST_ELEVATION_GAIN') {
+                        return `${Math.round(diff)} m more (${percentImprove}% improvement)`;
+                    }
                     return `${(diff / 1000).toFixed(2)} km more (${percentImprove}% improvement)`;
                 } else if (pr.unit === 'mps') {
                     return `${(diff * 3.6).toFixed(2)} km/h faster (${percentImprove}% improvement)`;


### PR DESCRIPTION
This PR fixes the analytics UI to display Highest Elevation Gain in meters instead of kilometers.

The value is already stored in meters. The issue was in frontend formatting, which treated all meters-based personal records as distance. This change keeps Longest Distance in kilometers while showing elevation gain correctly in meters, including the improvement text.