### PR TITLE
fix(profile): preserve bio line breaks in profile views

### DIFF
--- a/src/main/resources/templates/profile/public.html
+++ b/src/main/resources/templates/profile/public.html
@@ -46,7 +46,7 @@
                                     <p class="text-muted mb-2">
                                         <span id="username"></span>
                                     </p>
-                                    <p id="bio" class="mb-3"></p>
+                                    <p id="bio" class="mb-3 preserve-linebreaks"></p>
                                 </div>
                                 <div id="followButtonContainer" class="d-none">
                                     <button class="btn btn-primary" id="followBtn">

--- a/src/main/resources/templates/profile/view.html
+++ b/src/main/resources/templates/profile/view.html
@@ -46,7 +46,7 @@
                                     <p class="text-muted mb-2">
                                         <span id="username"></span>
                                     </p>
-                                    <p id="bio" class="mb-3"></p>
+                                    <p id="bio" class="mb-3 preserve-linebreaks"></p>
                                 </div>
                                 <div>
                                     <a th:href="@{/profile/edit}" class="btn btn-outline-primary">


### PR DESCRIPTION
Preserves line breaks in profile bio so multi-paragraph text renders correctly in both own and public profile views.